### PR TITLE
Misc artist coin QA finds

### DIFF
--- a/packages/common/src/api/tan-query/coins/useArtistCoinByTicker.ts
+++ b/packages/common/src/api/tan-query/coins/useArtistCoinByTicker.ts
@@ -31,7 +31,7 @@ export const fetchCoinTickerAvailability = async (
   const sdk = await audiusSdk()
   try {
     // Use getCoinByTicker - if it returns a coin, the ticker is taken
-    await sdk.coins.getCoinByTicker({ ticker: `$${ticker}` })
+    await sdk.coins.getCoinByTicker({ ticker })
     // If we get a coin back, the ticker is not available
     return { available: false }
   } catch (error: any) {

--- a/packages/common/src/messages/edit.ts
+++ b/packages/common/src/messages/edit.ts
@@ -72,7 +72,7 @@ export const priceAndAudienceMessages = {
     yourCoin: 'your coin',
     noCoins: 'No coins found. Launch a coin to enable this option.',
     description: (coinTicker: string) =>
-      `Anyone holding ${coinTicker} can stream.`
+      `Anyone holding $${coinTicker} can stream.`
   }
 }
 

--- a/packages/common/src/messages/launchpadMessages.ts
+++ b/packages/common/src/messages/launchpadMessages.ts
@@ -6,7 +6,8 @@ export const launchpadMessages = {
     congratsTitle: '🎉 Congrats!',
     congratsDescription:
       'Congrats on launching your artist coin on Audius! Time to share the good news with your fans.',
-    purchaseSummary: 'Purchase Summary',
+    purchaseSummaryTitle: 'Purchase Summary',
+    yourCoinTitle: 'Your Coin',
     addressTitle: 'Coin Address',
     shareToX: 'Share To X',
     uploadCoinGatedTrack: 'Upload Coin Gated Track'

--- a/packages/common/src/messages/walletMessages.ts
+++ b/packages/common/src/messages/walletMessages.ts
@@ -103,7 +103,7 @@ export const walletMessages = {
   receiveTokensLoadingSubtitle: 'Setting up your wallet',
   becomeMemberTitle: 'Become a member',
   becomeMemberBody: (coinTicker: string) =>
-    `Buy ${coinTicker} to gain access to exclusive members-only perks!`,
+    `Buy $${coinTicker} to gain access to exclusive members-only perks!`,
 
   // Linked Wallets messages
   linkedWallets: {

--- a/packages/common/src/utils/formatUtil.ts
+++ b/packages/common/src/utils/formatUtil.ts
@@ -195,9 +195,3 @@ export const formatDoubleDigit = (value: number) =>
  */
 export const formatTickerForUrl = (ticker: string) =>
   ticker.startsWith('$') ? ticker.slice(1) : ticker
-
-/**
- * Formats a ticker from url to be display friendly
- */
-export const formatTickerFromUrl = (ticker: string) =>
-  ticker.startsWith('$') ? ticker : `$${ticker}`

--- a/packages/mobile/src/screens/coin-details-screen/CoinDetailsScreen.tsx
+++ b/packages/mobile/src/screens/coin-details-screen/CoinDetailsScreen.tsx
@@ -20,7 +20,7 @@ export const CoinDetailsScreen = () => {
     <Screen
       url={route.ASSET_DETAIL_PAGE}
       variant='secondary'
-      title={ticker ?? 'Coin Details'}
+      title={ticker ? `$${ticker}` : 'Coin Details'}
     >
       <ScreenContent>
         <ScrollView>

--- a/packages/mobile/src/screens/wallet-screen/components/CoinCard.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/CoinCard.tsx
@@ -135,7 +135,7 @@ export const CoinCard = ({ mint, showUserBalance = true }: CoinCardProps) => {
                     ellipsizeMode='tail'
                     style={{ flexShrink: 1 }}
                   >
-                    {coinData?.ticker}
+                    ${coinData?.ticker}
                   </Text>
                 </Flex>
               </>

--- a/packages/web/src/components/CoinSuccessModal.tsx
+++ b/packages/web/src/components/CoinSuccessModal.tsx
@@ -108,7 +108,7 @@ export const CoinSuccessModal = () => {
               <Text variant='label' size='l' color='subdued'>
                 {launchpadMessages.modal.addressTitle}
               </Text>
-              <AddressTile address={mint} />
+              <AddressTile address={mint} shorten shortenLength={16} />
             </Flex>
 
             {/* Action Buttons */}

--- a/packages/web/src/components/CoinSuccessModal.tsx
+++ b/packages/web/src/components/CoinSuccessModal.tsx
@@ -58,33 +58,36 @@ export const CoinSuccessModal = () => {
             </Text>
 
             {/* Purchase Summary */}
-            {hasFirstBuyAmount ? (
-              <Flex column gap='m' w='100%'>
+
+            <Flex column gap='m' w='100%'>
+              {hasFirstBuyAmount ? (
                 <Text variant='label' size='l' color='subdued'>
                   {launchpadMessages.modal.purchaseSummary}
                 </Text>
-                <Paper
-                  p='m'
-                  gap='m'
-                  w='100%'
-                  borderRadius='m'
-                  border='default'
-                  shadow='flat'
-                  backgroundColor='surface1'
-                >
-                  <Flex alignItems='center' gap='m' w='100%'>
-                    <Artwork
-                      src={logoUri}
-                      w='48px'
-                      h='48px'
-                      hex
-                      borderWidth={0}
-                    />
+              ) : null}
+              <Paper
+                p='m'
+                gap='m'
+                w='100%'
+                borderRadius='m'
+                border='default'
+                shadow='flat'
+                backgroundColor='surface1'
+              >
+                <Flex alignItems='center' gap='m' w='100%'>
+                  <Artwork
+                    src={logoUri}
+                    w='48px'
+                    h='48px'
+                    hex
+                    borderWidth={0}
+                  />
 
-                    <Flex column gap='xs' flex={1}>
-                      <Text variant='title' size='m' color='default'>
-                        {name}
-                      </Text>
+                  <Flex column gap='xs' flex={1}>
+                    <Text variant='title' size='m' color='default'>
+                      {name}
+                    </Text>
+                    {hasFirstBuyAmount ? (
                       <Flex
                         alignItems='center'
                         justifyContent='space-between'
@@ -97,11 +100,13 @@ export const CoinSuccessModal = () => {
                           ${amountUsd}
                         </Text>
                       </Flex>
-                    </Flex>
+                    ) : (
+                      <Text color='subdued'>${ticker}</Text>
+                    )}
                   </Flex>
-                </Paper>
-              </Flex>
-            ) : null}
+                </Flex>
+              </Paper>
+            </Flex>
 
             {/* Contract Address Section */}
             <Flex column gap='m' w='100%'>

--- a/packages/web/src/components/CoinSuccessModal.tsx
+++ b/packages/web/src/components/CoinSuccessModal.tsx
@@ -41,6 +41,8 @@ export const CoinSuccessModal = () => {
 
   const { mint, name, ticker, logoUri, amountUi, amountUsd } = coinData
 
+  const hasFirstBuyAmount = amountUi !== '0' || amountUsd !== '0'
+
   return (
     <>
       <ConnectedMusicConfetti />
@@ -56,48 +58,50 @@ export const CoinSuccessModal = () => {
             </Text>
 
             {/* Purchase Summary */}
-            <Flex column gap='m' w='100%'>
-              <Text variant='label' size='l' color='subdued'>
-                {launchpadMessages.modal.purchaseSummary}
-              </Text>
-              <Paper
-                p='m'
-                gap='m'
-                w='100%'
-                borderRadius='m'
-                border='default'
-                shadow='flat'
-                backgroundColor='surface1'
-              >
-                <Flex alignItems='center' gap='m' w='100%'>
-                  <Artwork
-                    src={logoUri}
-                    w='48px'
-                    h='48px'
-                    hex
-                    borderWidth={0}
-                  />
+            {hasFirstBuyAmount ? (
+              <Flex column gap='m' w='100%'>
+                <Text variant='label' size='l' color='subdued'>
+                  {launchpadMessages.modal.purchaseSummary}
+                </Text>
+                <Paper
+                  p='m'
+                  gap='m'
+                  w='100%'
+                  borderRadius='m'
+                  border='default'
+                  shadow='flat'
+                  backgroundColor='surface1'
+                >
+                  <Flex alignItems='center' gap='m' w='100%'>
+                    <Artwork
+                      src={logoUri}
+                      w='48px'
+                      h='48px'
+                      hex
+                      borderWidth={0}
+                    />
 
-                  <Flex column gap='xs' flex={1}>
-                    <Text variant='title' size='m' color='default'>
-                      {name}
-                    </Text>
-                    <Flex
-                      alignItems='center'
-                      justifyContent='space-between'
-                      w='100%'
-                    >
-                      <Text variant='title' size='s' strength='weak'>
-                        {amountUi} <Text color='subdued'>${ticker}</Text>
+                    <Flex column gap='xs' flex={1}>
+                      <Text variant='title' size='m' color='default'>
+                        {name}
                       </Text>
-                      <Text variant='title' size='s' strength='weak'>
-                        ${amountUsd}
-                      </Text>
+                      <Flex
+                        alignItems='center'
+                        justifyContent='space-between'
+                        w='100%'
+                      >
+                        <Text variant='title' size='s' strength='weak'>
+                          {amountUi} <Text color='subdued'>${ticker}</Text>
+                        </Text>
+                        <Text variant='title' size='s' strength='weak'>
+                          ${amountUsd}
+                        </Text>
+                      </Flex>
                     </Flex>
                   </Flex>
-                </Flex>
-              </Paper>
-            </Flex>
+                </Paper>
+              </Flex>
+            ) : null}
 
             {/* Contract Address Section */}
             <Flex column gap='m' w='100%'>

--- a/packages/web/src/components/CoinSuccessModal.tsx
+++ b/packages/web/src/components/CoinSuccessModal.tsx
@@ -33,7 +33,7 @@ export const CoinSuccessModal = () => {
     if (!coinData?.ticker || !coinData?.mint) return
 
     const coinUrl = `https://audius.co${route.COIN_DETAIL_ROUTE.replace(':ticker', formatTickerForUrl(coinData.ticker))}`
-    const shareText = `My artist coin ${coinData.ticker} is live on @Audius. Be the first to buy and unlock my exclusive fan club!\n\n${coinData.mint}\n`
+    const shareText = `My artist coin $${coinData.ticker} is live on @Audius. Be the first to buy and unlock my exclusive fan club!\n\n${coinData.mint}\n`
     openXLink(coinUrl, shareText)
   }
 

--- a/packages/web/src/components/CoinSuccessModal.tsx
+++ b/packages/web/src/components/CoinSuccessModal.tsx
@@ -60,11 +60,11 @@ export const CoinSuccessModal = () => {
             {/* Purchase Summary */}
 
             <Flex column gap='m' w='100%'>
-              {hasFirstBuyAmount ? (
-                <Text variant='label' size='l' color='subdued'>
-                  {launchpadMessages.modal.purchaseSummary}
-                </Text>
-              ) : null}
+              <Text variant='label' size='l' color='subdued'>
+                {hasFirstBuyAmount
+                  ? launchpadMessages.modal.purchaseSummaryTitle
+                  : launchpadMessages.modal.yourCoinTitle}
+              </Text>
               <Paper
                 p='m'
                 gap='m'
@@ -101,7 +101,14 @@ export const CoinSuccessModal = () => {
                         </Text>
                       </Flex>
                     ) : (
-                      <Text color='subdued'>${ticker}</Text>
+                      <Text
+                        color='subdued'
+                        variant='title'
+                        size='s'
+                        strength='weak'
+                      >
+                        ${ticker}
+                      </Text>
                     )}
                   </Flex>
                 </Flex>

--- a/packages/web/src/components/address-tile/AddressTile.tsx
+++ b/packages/web/src/components/address-tile/AddressTile.tsx
@@ -22,12 +22,14 @@ type AddressTileProps = {
   address?: string
   iconRight?: IconComponent
   shorten?: boolean
+  shortenLength?: number
 }
 
 export const AddressTile = ({
   address,
   iconRight: IconRight,
-  shorten = false
+  shorten = false,
+  shortenLength = 12
 }: AddressTileProps) => {
   const { toast } = useContext(ToastContext)
   const isMobile = useIsMobile()
@@ -71,7 +73,9 @@ export const AddressTile = ({
             }}
             variant='body'
           >
-            {isMobile || shorten ? shortenSPLAddress(address, 12) : address}
+            {isMobile || shorten
+              ? shortenSPLAddress(address, shortenLength)
+              : address}
           </Text>
         </Box>
         <Flex alignItems='center' borderLeft='default' ph='l'>

--- a/packages/web/src/hooks/useClaimFees.ts
+++ b/packages/web/src/hooks/useClaimFees.ts
@@ -1,6 +1,7 @@
 import { type Coin } from '@audius/common/adapters'
 import { getArtistCoinQueryKey, useQueryContext } from '@audius/common/api'
 import { Feature } from '@audius/common/models'
+import { solana } from '@reown/appkit/networks'
 import type { Provider as SolanaProvider } from '@reown/appkit-adapter-solana/react'
 import { VersionedTransaction } from '@solana/web3.js'
 import {
@@ -41,6 +42,7 @@ export const useClaimFees = (
       receiverWalletAddress
     }: UseClaimFeesParams): Promise<ClaimFeesResponse> => {
       const sdk = await audiusSdk()
+      await appkitModal.switchNetwork(solana)
       const solanaProvider = appkitModal.getProvider<SolanaProvider>('solana')
       if (!solanaProvider) {
         throw new Error('Missing SolanaProvider')

--- a/packages/web/src/hooks/useLaunchCoin.ts
+++ b/packages/web/src/hooks/useLaunchCoin.ts
@@ -1,7 +1,6 @@
 import {
   getArtistCoinsQueryKey,
   getUserCreatedCoinsQueryKey,
-  getUserQueryKey,
   useQueryContext
 } from '@audius/common/api'
 import {

--- a/packages/web/src/hooks/useLaunchCoin.ts
+++ b/packages/web/src/hooks/useLaunchCoin.ts
@@ -1,6 +1,7 @@
 import {
   getArtistCoinsQueryKey,
   getUserCreatedCoinsQueryKey,
+  getUserQueryKey,
   useQueryContext
 } from '@audius/common/api'
 import {
@@ -89,10 +90,19 @@ export const useLaunchCoin = () => {
           // Triggers 3rd party wallet to sign the transaction, doesnt send to Solana just yet
           const signature =
             await solanaProvider.signAndSendTransaction(deserializedTx)
-          await sdk.services.solanaClient.connection.confirmTransaction(
-            signature,
-            'confirmed'
-          )
+          const result =
+            await sdk.services.solanaClient.connection.confirmTransaction(
+              signature,
+              'confirmed'
+            )
+
+          // Check if the transaction actually succeeded
+          if (result.value.err) {
+            throw new Error(
+              `Transaction confirmed but failed: ${JSON.stringify(result.value.err)}`
+            )
+          }
+
           return signature
         }
 

--- a/packages/web/src/pages/artist-coins-explore-page/ArtistCoinsExplorePage.tsx
+++ b/packages/web/src/pages/artist-coins-explore-page/ArtistCoinsExplorePage.tsx
@@ -62,14 +62,11 @@ const DesktopArtistCoinsExplorePage = () => {
       userId: currentUser?.user_id
     })
 
-  const hasExistingArtistCoin = false // (createdCoins?.length ?? 0) > 0
-  const canLaunchCoin = !hasExistingArtistCoin
+  const hasExistingArtistCoin = (createdCoins?.length ?? 0) > 0
 
   const handleGetStarted = useCallback(() => {
-    if (canLaunchCoin) {
-      navigate(COINS_CREATE_PAGE)
-    }
-  }, [navigate, canLaunchCoin])
+    navigate(COINS_CREATE_PAGE)
+  }, [navigate])
 
   const handleSearchChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setSearchValue(e.target.value)

--- a/packages/web/src/pages/artist-coins-explore-page/ArtistCoinsExplorePage.tsx
+++ b/packages/web/src/pages/artist-coins-explore-page/ArtistCoinsExplorePage.tsx
@@ -1,10 +1,6 @@
 import { useCallback, useState, ChangeEvent } from 'react'
 
-import {
-  useCurrentAccountUser,
-  useCurrentUserId,
-  useUserCreatedCoins
-} from '@audius/common/api'
+import { useCurrentAccountUser, useUserCreatedCoins } from '@audius/common/api'
 import { walletMessages } from '@audius/common/messages'
 import { COINS_CREATE_PAGE } from '@audius/common/src/utils/route'
 import {

--- a/packages/web/src/pages/artist-coins-explore-page/ArtistCoinsExplorePage.tsx
+++ b/packages/web/src/pages/artist-coins-explore-page/ArtistCoinsExplorePage.tsx
@@ -27,7 +27,6 @@ import { useNavigate } from 'react-router-dom-v5-compat'
 import imageCoinsBackgroundImage from 'assets/img/publicSite/imageCoinsBackgroundImage2x.webp'
 import { ExternalLink } from 'components/link'
 import Page from 'components/page/Page'
-import { Tooltip } from 'components/tooltip'
 import { isMobile } from 'utils/clientUtil'
 
 import { ArtistCoinsTable } from '../artist-coins-launchpad-page/components/ArtistCoinsTable'
@@ -58,14 +57,13 @@ const DesktopArtistCoinsExplorePage = () => {
   const navigate = useNavigate()
   const [searchValue, setSearchValue] = useState('')
   const { data: currentUser } = useCurrentAccountUser()
-  const { data: currentUserId } = useCurrentUserId()
-  const { data: createdCoins } = useUserCreatedCoins({
-    userId: currentUserId
-  })
+  const { data: createdCoins, isPending: isLoadingCreatedCoins } =
+    useUserCreatedCoins({
+      userId: currentUser?.user_id
+    })
 
-  const isVerified = currentUser?.is_verified ?? false
-  const hasExistingArtistCoin = (createdCoins?.length ?? 0) > 0
-  const canLaunchCoin = isVerified && !hasExistingArtistCoin
+  const hasExistingArtistCoin = false // (createdCoins?.length ?? 0) > 0
+  const canLaunchCoin = !hasExistingArtistCoin
 
   const handleGetStarted = useCallback(() => {
     if (canLaunchCoin) {
@@ -116,7 +114,7 @@ const DesktopArtistCoinsExplorePage = () => {
           </Box>
         </Flex>
 
-        {!hasExistingArtistCoin ? (
+        {!hasExistingArtistCoin && !isLoadingCreatedCoins ? (
           <Paper p='xl' gap='xl' border='default' borderRadius='m'>
             <Flex gap='xl' w='100%' wrap='wrap'>
               <Flex
@@ -156,24 +154,16 @@ const DesktopArtistCoinsExplorePage = () => {
                   </Flex>
                 </Flex>
 
-                <Tooltip
-                  text={messages.getStartedTooltip}
-                  placement='top'
-                  // Only show tooltip if user cannot launch a coin (not verified)
-                  disabled={canLaunchCoin}
-                >
-                  {/* Need to wrap with Flex because disabled button doesn't capture mouse events */}
-                  <Flex>
-                    <Button
-                      onClick={handleGetStarted}
-                      fullWidth
-                      disabled={!canLaunchCoin}
-                      color={canLaunchCoin ? 'coinGradient' : undefined}
-                    >
-                      {messages.getStarted}
-                    </Button>
-                  </Flex>
-                </Tooltip>
+                {/* Need to wrap with Flex because disabled button doesn't capture mouse events */}
+                <Flex>
+                  <Button
+                    onClick={handleGetStarted}
+                    fullWidth
+                    color='coinGradient'
+                  >
+                    {messages.getStarted}
+                  </Button>
+                </Flex>
               </Flex>
 
               <Box

--- a/packages/web/src/pages/artist-coins-explore-page/ArtistCoinsExplorePage.tsx
+++ b/packages/web/src/pages/artist-coins-explore-page/ArtistCoinsExplorePage.tsx
@@ -147,7 +147,6 @@ const DesktopArtistCoinsExplorePage = () => {
                   </Flex>
                 </Flex>
 
-                {/* Need to wrap with Flex because disabled button doesn't capture mouse events */}
                 <Flex>
                   <Button
                     onClick={handleGetStarted}

--- a/packages/web/src/pages/artist-coins-launchpad-page/components/ArtistCoinsTable.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/components/ArtistCoinsTable.tsx
@@ -94,7 +94,7 @@ const renderTokenNameCell = (cellInfo: CoinCell) => {
             ellipses
             css={{ display: 'block' }}
           >
-            {coin.ticker}
+            ${coin.ticker}
           </TextLink>
         </Flex>
       </Flex>

--- a/packages/web/src/pages/artist-coins-launchpad-page/components/LaunchpadBuyModal.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/components/LaunchpadBuyModal.tsx
@@ -284,6 +284,7 @@ const ConfirmationStep = ({
               title={buySellMessages.youPay}
               tokenInfo={values.selectedInputToken}
               amount={formattedPayAmount ?? ''}
+              hideUSDCTooltip
             />
             <SwapBalanceSection
               title={buySellMessages.youReceive}

--- a/packages/web/src/pages/artist-coins-launchpad-page/components/LaunchpadBuyModal.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/components/LaunchpadBuyModal.tsx
@@ -290,6 +290,7 @@ const ConfirmationStep = ({
               title={buySellMessages.youReceive}
               tokenInfo={values.selectedOutputToken}
               amount={formattedReceiveAmount ?? ''}
+              hideUSDCTooltip
             />
           </Flex>
 

--- a/packages/web/src/pages/artist-coins-launchpad-page/components/LaunchpadBuyModal.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/components/LaunchpadBuyModal.tsx
@@ -57,7 +57,7 @@ const INPUT_TOKEN_MAP: Record<string, TokenInfo & { minSwapAmount?: number }> =
 
 const INPUT_TOKEN_LIST = Object.values(INPUT_TOKEN_MAP)
 
-const DEFAULT_INPUT_TOKEN = INPUT_TOKEN_MAP.USDC
+const DEFAULT_INPUT_TOKEN = INPUT_TOKEN_MAP.SOL
 
 const OUTPUT_TOKEN: TokenInfo = {
   ...TOKEN_LISTING_MAP.AUDIO,

--- a/packages/web/src/pages/artist-coins-launchpad-page/constants.ts
+++ b/packages/web/src/pages/artist-coins-launchpad-page/constants.ts
@@ -20,4 +20,4 @@ export const AUDIO_DECIMALS = 8
 export const USDC_DECIMALS = 6
 export const TOKEN_DECIMALS = 9
 
-export const MIN_SOL_BALANCE = 300000 // 0.03 SOL - Minimum amount to launch a coin (0.0245 SOL) + a bit extra for swap fees
+export const MIN_SOL_BALANCE = 30000000 // 0.03 SOL - Minimum amount to launch a coin (0.0245 SOL) + a bit extra for swap fees

--- a/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
+++ b/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
@@ -104,7 +104,7 @@ export const AssetDetailPage = () => {
   ) : (
     <DesktopAssetDetailPageContent
       mint={coin?.mint ?? ''}
-      title={coin?.ticker ?? ''}
+      title={coin?.ticker ? `$${coin.ticker}` : ''}
       ticker={coin?.ticker ?? ''}
       isOwner={isOwner}
     />

--- a/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
@@ -11,7 +11,12 @@ import {
 import { useDiscordOAuthLink } from '@audius/common/hooks'
 import { coinDetailsMessages } from '@audius/common/messages'
 import { Feature, WidthSizes } from '@audius/common/models'
-import { removeNullable, route, shortenSPLAddress } from '@audius/common/utils'
+import {
+  formatCurrencyWithSubscript,
+  removeNullable,
+  route,
+  shortenSPLAddress
+} from '@audius/common/utils'
 import { wAUDIO } from '@audius/fixed-decimal'
 import {
   Flex,
@@ -301,13 +306,17 @@ export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
 
   const unclaimedFees = coin?.dynamicBondingCurve?.creatorQuoteFee ?? 0
   const formattedUnclaimedFees = useMemo(() => {
-    return wAUDIO(BigInt(unclaimedFees)).toShorthand()
+    return formatCurrencyWithSubscript(
+      Number(wAUDIO(BigInt(unclaimedFees)).toPrecision(8))
+    )
   }, [unclaimedFees])
   const totalArtistEarnings =
     coin?.dynamicBondingCurve?.totalTradingQuoteFee ?? 0
   const formattedTotalArtistEarnings = useMemo(() => {
     // Here we divide by 2 because the artist only gets half of the fees (this value includes the AUDIO network fees)
-    return wAUDIO(BigInt(Math.trunc(totalArtistEarnings / 2))).toShorthand()
+    return formatCurrencyWithSubscript(
+      Number(wAUDIO(BigInt(Math.trunc(totalArtistEarnings / 2))).toPrecision(8))
+    )
   }, [totalArtistEarnings])
   const descriptionParagraphs = coin?.description?.split('\n') ?? []
 

--- a/packages/web/src/pages/asset-detail-page/components/BalanceSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/BalanceSection.tsx
@@ -111,7 +111,7 @@ const ZeroBalanceState = ({
       <Flex gap='s' alignItems='center'>
         <TokenIcon logoURI={logoURI} />
         <Text variant='heading' size='l' color='subdued'>
-          {ticker}
+          ${ticker}
         </Text>
       </Flex>
       {!isCoinCreator ? (
@@ -210,7 +210,7 @@ const HasBalanceState = ({
                 {tokenBalanceFormatted}
               </Text>
               <Text variant='title' size='l' color='subdued'>
-                {ticker}
+                ${ticker}
               </Text>
             </Flex>
           </Flex>

--- a/packages/web/src/pages/asset-detail-page/components/BalanceSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/BalanceSection.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 
 import {
   useArtistCoin,
+  useCurrentAccountUser,
   useTokenBalance,
   useUSDCBalance
 } from '@audius/common/api'
@@ -98,8 +99,12 @@ const ZeroBalanceState = ({
   logoURI,
   onBuy,
   onReceive,
-  isBuySellSupported
-}: BalanceStateProps & { isBuySellSupported: boolean }) => {
+  isBuySellSupported,
+  isCoinCreator
+}: BalanceStateProps & {
+  isBuySellSupported: boolean
+  isCoinCreator: boolean
+}) => {
   const isManagerMode = useIsManagedAccount()
   return (
     <>
@@ -109,22 +114,24 @@ const ZeroBalanceState = ({
           {ticker}
         </Text>
       </Flex>
-      <Paper
-        ph='xl'
-        pv='l'
-        backgroundColor='surface2'
-        border='default'
-        direction='column'
-        gap='xs'
-        shadow='flat'
-      >
-        <Text variant='heading' size='s'>
-          {walletMessages.becomeMemberTitle}
-        </Text>
-        <Text variant='body' size='s' color='default' strength='default'>
-          {walletMessages.becomeMemberBody(ticker)}
-        </Text>
-      </Paper>
+      {!isCoinCreator ? (
+        <Paper
+          ph='xl'
+          pv='l'
+          backgroundColor='surface2'
+          border='default'
+          direction='column'
+          gap='xs'
+          shadow='flat'
+        >
+          <Text variant='heading' size='s'>
+            {walletMessages.becomeMemberTitle}
+          </Text>
+          <Text variant='body' size='s' color='default' strength='default'>
+            {walletMessages.becomeMemberBody(ticker)}
+          </Text>
+        </Paper>
+      ) : null}
       <Flex gap='s'>
         <Tooltip
           disabled={isBuySellSupported && !isManagerMode}
@@ -263,6 +270,8 @@ const BalanceSectionContent = ({ mint }: AssetDetailProps) => {
   const { data: coin, isPending: coinsLoading } = useArtistCoin(mint)
   const { data: tokenBalance, isPending: tokenBalanceLoading } =
     useTokenBalance({ mint })
+  const { data: currentUser } = useCurrentAccountUser()
+
   const { data: usdcBalance } = useUSDCBalance()
 
   const { isBuySellSupported } = useBuySellRegionSupport()
@@ -274,6 +283,7 @@ const BalanceSectionContent = ({ mint }: AssetDetailProps) => {
   const { onOpen: openReceiveTokensModal } = useReceiveTokensModal()
   const { onOpen: openSendTokensModal } = useSendTokensModal()
   const isMobile = useIsMobile()
+  const isCoinCreator = coin?.ownerId === currentUser?.user_id
   const [isOpenAppDrawerOpen, setIsOpenAppDrawerOpen] = useState(false)
 
   const history = useHistory()
@@ -347,6 +357,7 @@ const BalanceSectionContent = ({ mint }: AssetDetailProps) => {
             onBuy={isMobile ? onOpenOpenAppDrawer : handleAddCash}
             onReceive={handleReceive}
             isBuySellSupported={isBuySellSupported}
+            isCoinCreator={isCoinCreator}
           />
         ) : (
           <HasBalanceState

--- a/packages/web/src/pages/pay-and-earn-page/components/CoinCard.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/CoinCard.tsx
@@ -91,7 +91,7 @@ export const CoinCard = ({
                   {balance}
                 </Text>
                 <Text variant='title' size='l' color='subdued'>
-                  {symbol}
+                  ${symbol}
                 </Text>
               </Flex>
             </>


### PR DESCRIPTION
### Description

- Throw an error if TX confirms successfully but had an error on chain (this halts launchpad flow and goes into expected error handling states)
- Remove "Become a member" CTA for coin creators on their own coin
- Change default launchpad buy modal currency to SOL
- Add $ to a bunch of places
  - Share to X success modal
  - Upload coin gated track text
  - Explore coins table
  - Coin details page title
  - Launchpad coin ticker uniqueness check (important)
- Fix min sol balance on launchpad being off by 2 decimals 🙈 
- Fix success modal shortening address at end instead of middle
- Hide "purchase summary" from success modal if no purchase happened 

### How Has This Been Tested?

web:prod
