### PR TITLE
Fix transfers naming to be 24h

### DIFF
--- a/packages/common/src/messages/coinDetailsMessages.ts
+++ b/packages/common/src/messages/coinDetailsMessages.ts
@@ -30,7 +30,7 @@ export const coinDetailsMessages = {
     holdersOnAudius: 'Holders on Audius',
     uniqueHolders: 'Unique Holders',
     volume24hr: 'Volume (24hr)',
-    totalTransfers: 'Total Transfers',
+    totalTransfers: 'Transfers (24hr)',
     marketCap: 'Market Cap',
     unableToLoad: 'Unable to load insights',
     graduated: 'Graduated',

--- a/packages/common/src/utils/coinMetrics.ts
+++ b/packages/common/src/utils/coinMetrics.ts
@@ -16,7 +16,7 @@ const messages = {
   holdersOnAudius: 'Holders on Audius',
   uniqueHolders: 'Unique Holders',
   volume24hr: 'Volume (24hr)',
-  totalTransfers: 'Total Transfers',
+  totalTransfers: 'Transfers (24hr)',
   marketCap: 'Market Cap',
   graduationProgress: 'Graduation Progress'
 }


### PR DESCRIPTION
### Description

In future, this should be implemented using the all time trades API

https://public-api.birdeye.so/defi/v3/all-time/trades/single?time_frame=24h&ui_amount_mode=raw&address=C9iDQE9LirMaoAFknQaecBeZt8QxNSZVetMrAZ51Josg

instead

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
