### PR TITLE
[PE-7057] Several artist coins related fixes 

### DIFF
--- a/packages/web/src/pages/artist-coins-launchpad-page/components/ArtistCoinsTable.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/components/ArtistCoinsTable.tsx
@@ -275,8 +275,8 @@ const tableColumnMap = {
 const sortMethodMap: Record<string, GetCoinsSortMethodEnum> = {
   price: GetCoinsSortMethodEnum.Price,
   marketCap: GetCoinsSortMethodEnum.MarketCap,
-  volume24h: GetCoinsSortMethodEnum.Volume,
-  createdDate: GetCoinsSortMethodEnum.CreatedAt,
+  v24hUSD: GetCoinsSortMethodEnum.Volume,
+  createdAt: GetCoinsSortMethodEnum.CreatedAt,
   holder: GetCoinsSortMethodEnum.Holder
 }
 

--- a/packages/web/src/pages/asset-detail-page/components/ArtistCoinDetailsModal.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/ArtistCoinDetailsModal.tsx
@@ -48,7 +48,12 @@ export const ArtistCoinDetailsModal = ({
       size='s'
       isFullscreen
     >
-      <Flex direction='column' gap='l' p='l'>
+      <Flex
+        direction='column'
+        gap='l'
+        p='l'
+        css={{ overflowY: 'auto', maxHeight: '100%' }}
+      >
         {/* Token Info Section */}
         <Flex direction='column' gap='m'>
           <Flex alignItems='center' gap='m'>

--- a/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
@@ -6,11 +6,13 @@ import {
   useUser,
   useUserCoins,
   useConnectedWallets,
-  useCurrentAccountUser
+  useCurrentAccountUser,
+  type ConnectedWallet
 } from '@audius/common/api'
 import { useDiscordOAuthLink } from '@audius/common/hooks'
 import { coinDetailsMessages } from '@audius/common/messages'
 import { Feature, WidthSizes } from '@audius/common/models'
+import type { User } from '@audius/common/models'
 import {
   formatCurrencyWithSubscript,
   removeNullable,
@@ -260,6 +262,115 @@ type AssetInfoSectionProps = {
 
 const { REWARDS_PAGE } = route
 
+type AssetDetailsSectionProps = {
+  formattedTotalArtistEarnings: string
+  isCoinCreator: boolean
+  unclaimedFees: number
+  formattedUnclaimedFees: string
+  isClaimFeesPending: boolean
+  handleClaimFees: () => void
+  externalSolWallet: ConnectedWallet | undefined
+  currentUser: User | null | undefined
+}
+
+const AssetDetailsSection = ({
+  formattedTotalArtistEarnings,
+  isCoinCreator,
+  unclaimedFees,
+  formattedUnclaimedFees,
+  isClaimFeesPending,
+  handleClaimFees,
+  externalSolWallet,
+  currentUser
+}: AssetDetailsSectionProps) => {
+  return (
+    <Flex
+      direction='column'
+      alignItems='flex-start'
+      alignSelf='stretch'
+      borderTop='default'
+      ph='xl'
+      pv='l'
+      gap='l'
+    >
+      <Flex
+        alignItems='center'
+        justifyContent='space-between'
+        alignSelf='stretch'
+      >
+        <Flex alignItems='center' gap='s'>
+          <Text variant='body' size='s' strength='strong'>
+            {overflowMessages.vestingSchedule}
+          </Text>
+          <Tooltip text={overflowMessages.vestingSchedule} mount='body'>
+            <IconInfo size='s' color='subdued' />
+          </Tooltip>
+        </Flex>
+        <Text variant='body' size='s' color='subdued'>
+          {overflowMessages.vestingScheduleValue}
+        </Text>
+      </Flex>
+      <Flex
+        alignItems='center'
+        justifyContent='space-between'
+        alignSelf='stretch'
+      >
+        <Flex alignItems='center' gap='s'>
+          <Text variant='body' size='s' strength='strong'>
+            {overflowMessages.artistEarnings}
+          </Text>
+          <Tooltip text={overflowMessages.artistEarnings} mount='body'>
+            <IconInfo size='s' color='subdued' />
+          </Tooltip>
+        </Flex>
+        <Text variant='body' size='s' color='subdued'>
+          {formattedTotalArtistEarnings} {overflowMessages.$audio}
+        </Text>
+      </Flex>
+      {isCoinCreator ? (
+        <Flex
+          alignItems='center'
+          justifyContent='space-between'
+          alignSelf='stretch'
+        >
+          <Flex alignItems='center' gap='s'>
+            <Text variant='body' size='s' strength='strong'>
+              {overflowMessages.unclaimedFees}
+            </Text>
+            <Tooltip text={overflowMessages.unclaimedFees} mount='body'>
+              <IconInfo size='s' color='subdued' />
+            </Tooltip>
+          </Flex>
+          <Flex alignItems='center' gap='s'>
+            {unclaimedFees > 0 ? (
+              <Flex gap='xs' alignItems='center'>
+                <TextLink
+                  onClick={handleClaimFees}
+                  variant={isClaimFeesPending ? 'subdued' : 'visible'}
+                  disabled={
+                    isClaimFeesPending ||
+                    !externalSolWallet ||
+                    !currentUser?.spl_wallet
+                  }
+                >
+                  {overflowMessages.claim}
+                </TextLink>
+                {isClaimFeesPending ? (
+                  <LoadingSpinner size='s' color='subdued' />
+                ) : null}
+              </Flex>
+            ) : null}
+
+            <Text variant='body' size='s' color='subdued'>
+              {formattedUnclaimedFees} {overflowMessages.$audio}
+            </Text>
+          </Flex>
+        </Flex>
+      ) : null}
+    </Flex>
+  )
+}
+
 export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
   const dispatch = useDispatch()
   const { toast } = useContext(ToastContext)
@@ -487,90 +598,18 @@ export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
           {shortenSPLAddress(mint)}
         </Text>
       </Flex>
-      <Flex
-        direction='column'
-        alignItems='flex-start'
-        alignSelf='stretch'
-        borderTop='default'
-        ph='xl'
-        pv='l'
-        gap='l'
-      >
-        <Flex
-          alignItems='center'
-          justifyContent='space-between'
-          alignSelf='stretch'
-        >
-          <Flex alignItems='center' gap='s'>
-            <Text variant='body' size='s' strength='strong'>
-              {overflowMessages.vestingSchedule}
-            </Text>
-            <Tooltip text={overflowMessages.vestingSchedule}>
-              <IconInfo size='s' color='subdued' />
-            </Tooltip>
-          </Flex>
-          <Text variant='body' size='s' color='subdued'>
-            {overflowMessages.vestingScheduleValue}
-          </Text>
-        </Flex>
-        <Flex
-          alignItems='center'
-          justifyContent='space-between'
-          alignSelf='stretch'
-        >
-          <Flex alignItems='center' gap='s'>
-            <Text variant='body' size='s' strength='strong'>
-              {overflowMessages.artistEarnings}
-            </Text>
-            <Tooltip text={overflowMessages.artistEarnings}>
-              <IconInfo size='s' color='subdued' />
-            </Tooltip>
-          </Flex>
-          <Text variant='body' size='s' color='subdued'>
-            {formattedTotalArtistEarnings} {overflowMessages.$audio}
-          </Text>
-        </Flex>
-        {isCoinCreator ? (
-          <Flex
-            alignItems='center'
-            justifyContent='space-between'
-            alignSelf='stretch'
-          >
-            <Flex alignItems='center' gap='s'>
-              <Text variant='body' size='s' strength='strong'>
-                {overflowMessages.unclaimedFees}
-              </Text>
-              <Tooltip text={overflowMessages.unclaimedFees}>
-                <IconInfo size='s' color='subdued' />
-              </Tooltip>
-            </Flex>
-            <Flex alignItems='center' gap='s'>
-              {unclaimedFees > 0 ? (
-                <Flex gap='xs' alignItems='center'>
-                  <TextLink
-                    onClick={handleClaimFees}
-                    variant={isClaimFeesPending ? 'subdued' : 'visible'}
-                    disabled={
-                      isClaimFeesPending ||
-                      !externalSolWallet ||
-                      !currentUser?.spl_wallet
-                    }
-                  >
-                    {overflowMessages.claim}
-                  </TextLink>
-                  {isClaimFeesPending ? (
-                    <LoadingSpinner size='s' color='subdued' />
-                  ) : null}
-                </Flex>
-              ) : null}
-
-              <Text variant='body' size='s' color='subdued'>
-                {formattedUnclaimedFees} {overflowMessages.$audio}
-              </Text>
-            </Flex>
-          </Flex>
-        ) : null}
-      </Flex>
+      {!isWAudio ? (
+        <AssetDetailsSection
+          formattedTotalArtistEarnings={formattedTotalArtistEarnings}
+          isCoinCreator={isCoinCreator}
+          unclaimedFees={unclaimedFees}
+          formattedUnclaimedFees={formattedUnclaimedFees}
+          isClaimFeesPending={isClaimFeesPending}
+          handleClaimFees={handleClaimFees}
+          externalSolWallet={externalSolWallet}
+          currentUser={currentUser}
+        />
+      ) : null}
     </Paper>
   )
 }

--- a/packages/web/src/pages/pay-and-earn-page/components/CoinCard.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/CoinCard.tsx
@@ -75,24 +75,30 @@ export const CoinCard = ({
       onClick={onClick}
       css={{
         cursor: onClick ? 'pointer' : 'default',
+        minWidth: 0,
         '&:hover': onClick ? { backgroundColor: color.background.surface2 } : {}
       }}
     >
-      <Flex alignItems='center' gap='l'>
+      <Flex alignItems='center' gap='l' css={{ minWidth: 0, flex: 1 }}>
         {loading ? <HexagonSkeleton /> : renderIcon()}
-        <Flex direction='column' gap='2xs' flex={1}>
+        <Flex direction='column' gap='2xs' flex={1} css={{ minWidth: 0 }}>
           {loading ? (
             <CoinCardSkeleton />
           ) : (
             <>
-              <Text variant='heading' size='s'>
+              <Text variant='heading' size='s' css={{ wordWrap: 'break-word' }}>
                 {name}
               </Text>
-              <Flex gap='xs' alignItems='center'>
-                <Text variant='title' size='l'>
+              <Flex gap='xs' alignItems='center' css={{ flexWrap: 'wrap' }}>
+                <Text variant='title' size='l' css={{ wordWrap: 'break-word' }}>
                   {balance}
                 </Text>
-                <Text variant='title' size='l' color='subdued'>
+                <Text
+                  variant='title'
+                  size='l'
+                  color='subdued'
+                  css={{ wordWrap: 'break-word' }}
+                >
                   {noDollarSignPrefix ? symbol : `$${symbol}`}
                 </Text>
               </Flex>
@@ -100,7 +106,7 @@ export const CoinCard = ({
           )}
         </Flex>
       </Flex>
-      <Flex alignItems='center' gap='m'>
+      <Flex alignItems='center' gap='m' css={{ flexShrink: 0 }}>
         {!loading && (
           <Text variant='title' size='l' color='default'>
             {heldValue ?? dollarValue}

--- a/packages/web/src/pages/pay-and-earn-page/components/YourCoins.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/YourCoins.tsx
@@ -306,7 +306,9 @@ export const YourCoins = () => {
           <Box
             css={{
               display: 'grid',
-              gridTemplateColumns: isSingleColumn ? '1fr' : '1fr 1fr',
+              gridTemplateColumns: isSingleColumn
+                ? 'minmax(0, 1fr)'
+                : 'minmax(0, 1fr) minmax(0, 1fr)',
               gap: '0'
             }}
           >


### PR DESCRIPTION
### Description

This PR includes several fixes for the artist coins features:

### Changes

- **Artist Coins Table**: Fixed volume sorting key mapping from `volume24h` to `v24hUSD` and `createdDate` to `createdAt`
- **Coin Cards**: Added responsive styling with `minWidth: 0`, `wordWrap: 'break-word'`, and `flexShrink: 0` to prevent layout issues on mobile web
- **Artist Coin Details Modal**: Made the modal scrollable by adding `overflowY: 'auto'` and `maxHeight: '100%'`
- **Asset Info Section**:
  - Extracted `AssetDetailsSection` component for better organization
  - Fixed tooltip mounting to use `mount='body'`
  - Only render asset details section for non-wAUDIO tokens

### Motivation

These changes improve the mobile web experience and fix sorting functionality in the artist coins launchpad page.

### How Has This Been Tested?

`npm run web:prod`
