### PR TITLE
[PE-7100] Highlight artist coin left nav on coins

### DIFF
--- a/packages/web/src/components/nav/desktop/nav-items/ArtistCoinsNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/nav-items/ArtistCoinsNavItem.tsx
@@ -24,7 +24,7 @@ export const ArtistCoinsNavItem = () => {
     <LeftNavLink
       leftIcon={IconArtistCoin}
       to={COINS_EXPLORE_PAGE}
-      exact
+      additionalPathMatches={['/coins/']}
       restriction='none'
     >
       {messages.title}


### PR DESCRIPTION
### Description

<img width="706" height="455" alt="image" src="https://github.com/user-attachments/assets/85fabc92-9c1f-4fd4-a070-1f73e8412b9f" />
