### PR TITLE
[PE-7097] Hide balance/wallet-related coin assets details for anon users

### DIFF
--- a/packages/web/src/pages/asset-detail-page/AssetDetailContent.tsx
+++ b/packages/web/src/pages/asset-detail-page/AssetDetailContent.tsx
@@ -53,21 +53,25 @@ const useStyles = makeResponsiveStyles(({ media, theme }) => {
 
 type AssetDetailContentProps = {
   mint: string
+  isAnonymousUser: boolean
 }
 
-export const AssetDetailContent = ({ mint }: AssetDetailContentProps) => {
+export const AssetDetailContent = ({
+  mint,
+  isAnonymousUser
+}: AssetDetailContentProps) => {
   const styles = useStyles()
 
   return (
     <Flex css={styles.container}>
       <Flex css={styles.leftSection}>
-        <BalanceSection mint={mint} />
+        {isAnonymousUser ? null : <BalanceSection mint={mint} />}
         <AssetInfoSection mint={mint} />
       </Flex>
       <Flex css={styles.rightSection}>
         <AssetInsights mint={mint} />
         <AssetLeaderboardCard mint={mint} />
-        <ExternalWallets mint={mint} />
+        {isAnonymousUser ? null : <ExternalWallets mint={mint} />}
       </Flex>
     </Flex>
   )

--- a/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
+++ b/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
@@ -14,18 +14,25 @@ import { useAssetDetailTabs } from './AssetDetailTabs'
 type AssetDetailPageContentProps = {
   mint: string
   title: string
+  isAnonymousUser: boolean
 }
 
 const DesktopAssetDetailPageContent = ({
   mint,
   title,
   ticker,
-  isOwner
-}: AssetDetailPageContentProps & { ticker: string; isOwner: boolean }) => {
+  isOwner,
+  isAnonymousUser
+}: AssetDetailPageContentProps & {
+  ticker: string
+  isOwner: boolean
+  isAnonymousUser: boolean
+}) => {
   const { tabs, body, rightDecorator } = useAssetDetailTabs({
     mint,
     ticker,
-    isOwner
+    isOwner,
+    isAnonymousUser
   })
 
   const header = (
@@ -46,9 +53,10 @@ const DesktopAssetDetailPageContent = ({
 
 const MobileAssetDetailPageContent = ({
   mint,
-  title
+  title,
+  isAnonymousUser
 }: AssetDetailPageContentProps) => {
-  const { body } = useAssetDetailTabs({ mint })
+  const { body } = useAssetDetailTabs({ mint, isAnonymousUser })
 
   return (
     <MobilePageContainer
@@ -100,6 +108,7 @@ export const AssetDetailPage = () => {
     <MobileAssetDetailPageContent
       mint={coin?.mint ?? ''}
       title={coin?.ticker ?? ''}
+      isAnonymousUser={!currentUserId}
     />
   ) : (
     <DesktopAssetDetailPageContent
@@ -107,6 +116,7 @@ export const AssetDetailPage = () => {
       title={coin?.name ?? ''}
       ticker={coin?.ticker ?? ''}
       isOwner={isOwner}
+      isAnonymousUser={!currentUserId}
     />
   )
 }

--- a/packages/web/src/pages/asset-detail-page/AssetDetailTabs.tsx
+++ b/packages/web/src/pages/asset-detail-page/AssetDetailTabs.tsx
@@ -26,12 +26,14 @@ type UseAssetDetailTabsProps = {
   mint: string
   ticker?: string
   isOwner?: boolean
+  isAnonymousUser?: boolean
 }
 
 export const useAssetDetailTabs = ({
   mint,
   ticker,
-  isOwner = false
+  isOwner = false,
+  isAnonymousUser = false
 }: UseAssetDetailTabsProps) => {
   const [selectedTab, setSelectedTab] = useState(AssetDetailTabType.HOME)
   const navigate = useNavigate()
@@ -61,7 +63,11 @@ export const useAssetDetailTabs = ({
   ]
 
   const tabElements = [
-    <AssetDetailContent key='home' mint={mint} />,
+    <AssetDetailContent
+      key='home'
+      mint={mint}
+      isAnonymousUser={isAnonymousUser}
+    />,
     <AudioWalletTransactions key='transactions' />
   ]
 
@@ -83,7 +89,9 @@ export const useAssetDetailTabs = ({
   if (!isWAudio) {
     return {
       tabs: null,
-      body: <AssetDetailContent mint={mint} />,
+      body: (
+        <AssetDetailContent mint={mint} isAnonymousUser={isAnonymousUser} />
+      ),
       rightDecorator
     }
   }


### PR DESCRIPTION
### Description
Prevent rendering skeleton/useless sections when viewing coin details while logged out.

NOTE: I had to temporarily override the feature flag locally to prevent the audio page from flashing and causing a redirect to sign up. This won't be an issue in deployed enivornments.

### How Has This Been Tested?
`npm run web:*` and view `/coins/:ticker` while logged out.
