### PR TITLE
Create user bank to claim fees

### DIFF
--- a/packages/web/src/hooks/useClaimFees.ts
+++ b/packages/web/src/hooks/useClaimFees.ts
@@ -1,7 +1,11 @@
 import { type Coin } from '@audius/common/adapters'
-import { getArtistCoinQueryKey, useQueryContext } from '@audius/common/api'
-import { QUERY_KEYS } from '@audius/common/api'
+import {
+  getArtistCoinQueryKey,
+  useQueryContext,
+  QUERY_KEYS
+} from '@audius/common/api'
 import { Feature } from '@audius/common/models'
+import { createUserBankIfNeeded } from '@audius/common/services'
 import { solana } from '@reown/appkit/networks'
 import type { Provider as SolanaProvider } from '@reown/appkit-adapter-solana/react'
 import { VersionedTransaction } from '@solana/web3.js'
@@ -12,12 +16,13 @@ import {
 } from '@tanstack/react-query'
 
 import { appkitModal } from 'app/ReownAppKitModal'
+import { track } from 'services/analytics'
 import { reportToSentry } from 'store/errors/reportToSentry'
 
 export type UseClaimFeesParams = {
   tokenMint: string
   ownerWalletAddress: string
-  receiverWalletAddress: string
+  ownerEthAddress: string
 }
 
 export type ClaimFeesResponse = {
@@ -40,7 +45,7 @@ export const useClaimFees = (
     mutationFn: async ({
       tokenMint,
       ownerWalletAddress,
-      receiverWalletAddress
+      ownerEthAddress
     }: UseClaimFeesParams): Promise<ClaimFeesResponse> => {
       const sdk = await audiusSdk()
       await appkitModal.switchNetwork(solana)
@@ -51,12 +56,20 @@ export const useClaimFees = (
       if (!ownerWalletAddress) {
         throw new Error('Missing owner wallet address')
       }
+      if (!ownerEthAddress) {
+        throw new Error('Missing owner ETH address')
+      }
+      const userBank = await createUserBankIfNeeded(sdk, {
+        recordAnalytics: track,
+        mint: 'wAUDIO',
+        ethAddress: ownerEthAddress
+      })
 
       // Get the claim fee transaction from the relay
       const claimFeesResponse = await sdk.services.solanaRelay.claimFees({
         tokenMint,
         ownerWalletAddress,
-        receiverWalletAddress
+        receiverWalletAddress: userBank.toString()
       })
 
       const { claimFeesTx: claimFeesTxSerialized } = claimFeesResponse

--- a/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
@@ -448,7 +448,7 @@ export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
   }, [mint, toast])
 
   const handleClaimFees = useCallback(() => {
-    if (!externalSolWallet || !mint || !currentUser?.spl_wallet) {
+    if (!externalSolWallet || !mint || !currentUser?.wallet) {
       toast(toastMessages.feesClaimFailed)
       reportToSentry({
         error: new Error('Unknown error while claiming fees'),
@@ -467,7 +467,7 @@ export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
     claimFees({
       tokenMint: mint,
       ownerWalletAddress: externalSolWallet.address,
-      receiverWalletAddress: currentUser.spl_wallet // Using same wallet for owner and receiver
+      ownerEthAddress: currentUser.wallet!
     })
   }, [externalSolWallet, mint, currentUser, claimFees, toast, coin])
 
@@ -604,9 +604,7 @@ export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
           unclaimedFees={unclaimedFees}
           formattedUnclaimedFees={formattedUnclaimedFees}
           isClaimFeesPending={isClaimFeesPending}
-          isClaimFeesDisabled={
-            isClaimFeesPending || !externalSolWallet || !currentUser?.spl_wallet
-          }
+          isClaimFeesDisabled={isClaimFeesPending || !externalSolWallet}
           handleClaimFees={handleClaimFees}
         />
       ) : null}


### PR DESCRIPTION
### Description

Currently if the user has no audio user bank, fee claiming wont work, so instead of passing a user bank address, pass their eth one and derive the user bank.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

claimed fees on prod