### PR TITLE
Refresh balances when in buy/sell/swap flow

### DIFF
--- a/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
+++ b/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
@@ -200,7 +200,7 @@ export const useAudioBalance = (
           : [])
       ]
     },
-    { enabled: isUserFetched }
+    { ...options, enabled: isUserFetched }
   )
   let accountBalance = AUDIO(0).value
 

--- a/packages/common/src/hooks/useOwnedTokens.ts
+++ b/packages/common/src/hooks/useOwnedTokens.ts
@@ -18,7 +18,10 @@ import { ownedCoinsFilter } from '~/utils'
  */
 export const useOwnedTokens = (allTokens: TokenInfo[]) => {
   const { data: currentUserId } = useCurrentUserId()
-  const { data: userCoins } = useUserCoins({ userId: currentUserId })
+  const { data: userCoins } = useUserCoins(
+    { userId: currentUserId },
+    { refetchInterval: 5000 }
+  )
   const { data: usdcBalance } = useUSDCBalance()
   const { env } = useQueryContext()
   const { isEnabled: isArtistCoinsEnabled } = useFeatureFlag(

--- a/packages/common/src/store/ui/buy-sell/hooks/useTokenData.ts
+++ b/packages/common/src/store/ui/buy-sell/hooks/useTokenData.ts
@@ -6,7 +6,7 @@
 
 import { useMemo } from 'react'
 
-import { useTokenBalance, useTokenExchangeRate } from '~/api'
+import { QueryOptions, useTokenBalance, useTokenExchangeRate } from '~/api'
 import { useExternalWalletBalance } from '~/api/tan-query/wallets/useExternalWalletBalance'
 import { getTokenDecimalPlaces } from '~/utils'
 
@@ -21,13 +21,15 @@ export type UseTokenDataProps = {
   outputToken: TokenInfo
   inputAmount: number
   externalWalletAddress?: string
+  queryOptions?: QueryOptions
 }
 
 export const useTokenData = ({
   inputToken,
   outputToken,
   inputAmount,
-  externalWalletAddress
+  externalWalletAddress,
+  queryOptions
 }: UseTokenDataProps): TokenDataHookResult => {
   // Get token balance from internal wallet
   const {
@@ -37,7 +39,8 @@ export const useTokenData = ({
     mint: inputToken.address,
     includeExternalWallets: false,
     includeStaked: false,
-    enabled: !externalWalletAddress
+    enabled: !externalWalletAddress,
+    ...queryOptions
   })
 
   // Get token balance from an explicit external wallet
@@ -49,7 +52,7 @@ export const useTokenData = ({
       walletAddress: externalWalletAddress,
       mint: inputToken.address
     },
-    { enabled: !!externalWalletAddress }
+    { ...queryOptions, enabled: !!externalWalletAddress }
   )
 
   // Use whichever balance based on configuration

--- a/packages/common/src/store/ui/buy-sell/useTokenSwapForm.ts
+++ b/packages/common/src/store/ui/buy-sell/useTokenSwapForm.ts
@@ -95,7 +95,10 @@ export const useTokenSwapForm = ({
     inputToken,
     outputToken,
     inputAmount: parseNumericAmount(initialInputValue),
-    externalWalletAddress
+    externalWalletAddress,
+    queryOptions: {
+      refetchInterval: 5000
+    }
   })
 
   const swapCalculations = useSwapCalculations({


### PR DESCRIPTION
### Description

Pass through query params and use a 5s interval to refetch owned tokens & token info for convert flows.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Sent 5 $AUDIO while I had the convert flow open swapping _from_ $AUDIO. saw balance refresh live and was able to use the funds