### PR TITLE
[PE-7093] Fix claiming provider issues

### DIFF
--- a/packages/common/src/messages/coinDetailsMessages.ts
+++ b/packages/common/src/messages/coinDetailsMessages.ts
@@ -124,6 +124,8 @@ export const coinDetailsMessages = {
   },
   toasts: {
     feesClaimed: 'Fees claimed successfully!',
-    feesClaimFailed: 'Unable to claim fees. Please try again.'
+    feesClaimFailed: 'Unable to claim fees. Please try again.',
+    incorrectWalletLinked:
+      'Incorrect wallet linked. Use the same wallet used to launch the coin.'
   }
 }

--- a/packages/common/src/utils/decimal.ts
+++ b/packages/common/src/utils/decimal.ts
@@ -174,9 +174,10 @@ export const formatCurrency = (
  */
 export const formatCurrencyWithSubscript = (
   num: number,
-  locale: string = 'en-US'
+  locale: string = 'en-US',
+  prefix: string = '$'
 ): string => {
-  if (num === 0) return '$0.00'
+  if (num === 0) return `${prefix}0.00`
 
   try {
     const decimalPlaces = getCurrencyDecimalPlaces(num)
@@ -225,14 +226,14 @@ export const formatCurrencyWithSubscript = (
             .join('')
 
           // Format as $0.0[subscript][remaining digits]
-          return `$0.0${subscriptDigits}${remainingDigits}`
+          return `${prefix}0.0${subscriptDigits}${remainingDigits}`
         }
       }
     }
 
-    return formatted
+    return formatted.replace('$', prefix)
   } catch {
-    return `$${num.toFixed(2)}`
+    return `${prefix}${num.toFixed(2)}`
   }
 }
 

--- a/packages/sdk/src/sdk/api/generated/default/models/CoinDynamicBondingCurve.ts
+++ b/packages/sdk/src/sdk/api/generated/default/models/CoinDynamicBondingCurve.ts
@@ -62,6 +62,12 @@ export interface CoinDynamicBondingCurve {
      * @memberof CoinDynamicBondingCurve
      */
     totalTradingQuoteFee: number;
+    /**
+     * Address of the pool creator's wallet
+     * @type {string}
+     * @memberof CoinDynamicBondingCurve
+     */
+    creatorWalletAddress: string;
 }
 
 /**
@@ -75,6 +81,7 @@ export function instanceOfCoinDynamicBondingCurve(value: object): value is CoinD
     isInstance = isInstance && "curveProgress" in value && value["curveProgress"] !== undefined;
     isInstance = isInstance && "creatorQuoteFee" in value && value["creatorQuoteFee"] !== undefined;
     isInstance = isInstance && "totalTradingQuoteFee" in value && value["totalTradingQuoteFee"] !== undefined;
+    isInstance = isInstance && "creatorWalletAddress" in value && value["creatorWalletAddress"] !== undefined;
 
     return isInstance;
 }
@@ -96,6 +103,7 @@ export function CoinDynamicBondingCurveFromJSONTyped(json: any, ignoreDiscrimina
         'isMigrated': !exists(json, 'isMigrated') ? undefined : json['isMigrated'],
         'creatorQuoteFee': json['creatorQuoteFee'],
         'totalTradingQuoteFee': json['totalTradingQuoteFee'],
+        'creatorWalletAddress': json['creatorWalletAddress'],
     };
 }
 
@@ -115,6 +123,7 @@ export function CoinDynamicBondingCurveToJSON(value?: CoinDynamicBondingCurve | 
         'isMigrated': value.isMigrated,
         'creatorQuoteFee': value.creatorQuoteFee,
         'totalTradingQuoteFee': value.totalTradingQuoteFee,
+        'creatorWalletAddress': value.creatorWalletAddress,
     };
 }
 

--- a/packages/web/src/hooks/useClaimFees.ts
+++ b/packages/web/src/hooks/useClaimFees.ts
@@ -7,7 +7,6 @@ import {
 } from '@audius/common/api'
 import { Feature } from '@audius/common/models'
 import { createUserBankIfNeeded } from '@audius/common/services'
-import { solana } from '@reown/appkit/networks'
 import type { Provider as SolanaProvider } from '@reown/appkit-adapter-solana/react'
 import { VersionedTransaction } from '@solana/web3.js'
 import {
@@ -69,7 +68,7 @@ export const useClaimFees = (
       // Get the claim fee transaction from the relay
       const claimFeesResponse = await sdk.services.solanaRelay.claimFees({
         tokenMint,
-        externalWalletAddress,
+        ownerWalletAddress: externalWalletAddress,
         receiverWalletAddress: userBank.toString()
       })
 

--- a/packages/web/src/hooks/useConnectAndAssociateWallets.ts
+++ b/packages/web/src/hooks/useConnectAndAssociateWallets.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback } from 'react'
 
 import {
   type ConnectedWallet,
@@ -8,17 +8,15 @@ import {
 } from '@audius/common/api'
 import { useAppContext } from '@audius/common/context'
 import { Name, Chain } from '@audius/common/models'
-import { useTheme } from '@emotion/react'
 import type { NamespaceTypeMap } from '@reown/appkit'
-import { mainnet } from '@reown/appkit/networks'
-import { useAppKit, useDisconnect } from '@reown/appkit/react'
+import type { EventsControllerState } from '@reown/appkit/react'
 import type { Provider as SolanaProvider } from '@reown/appkit-adapter-solana/react'
 import type { Hex } from 'viem'
-import { useSignMessage, useSwitchAccount, useAccount } from 'wagmi'
+import { useSignMessage } from 'wagmi'
 
-import { appkitModal, wagmiAdapter, audiusChain } from 'app/ReownAppKitModal'
+import { appkitModal, wagmiAdapter } from 'app/ReownAppKitModal'
 
-import { useRequiresAccountCallback } from './useRequiresAccount'
+import { useConnectWallets } from './useConnectWallets'
 
 /**
  * Helper hook that signs a message using the current connected wallet, whether
@@ -88,84 +86,15 @@ export const useConnectAndAssociateWallets = (
   const {
     analytics: { track, make }
   } = useAppContext()
-  const theme = useTheme()
-  const { open: openAppKitModal, close: closeAppKitModal } = useAppKit()
   const { signMessageAgnostic } = useSignMessageAgnostic()
   const { data: currentUser } = useCurrentAccountUser()
   const { data: connectedWallets } = useConnectedWallets()
-  const { switchAccountAsync } = useSwitchAccount()
-  const { disconnect } = useDisconnect()
-
-  // The state goes from modal open => connecting => associating
-  // Explicitly manage our own state for the open state of the modal
-  // since their might be multiple hook instances listening for events
-  const [isAppKitModalOpen, setIsAppKitModalOpen] = useState(false)
-  const [isConnecting, setIsConnecting] = useState(false)
   const [isAssociating, setIsAssociating] = useState(false)
-
-  // Keep track of any existing connected external wallets
-  const { isConnected, connector, chainId } = useAccount()
-  const originalConnectorRef = useRef(connector)
-  const originalChainIdRef = useRef(chainId)
-  const usingExternalWalletAuthRef = useRef(
-    !!originalConnectorRef.current &&
-      originalChainIdRef.current === audiusChain.id
-  )
 
   const { mutateAsync: addConnectedWalletAsync } = useAddConnectedWallet()
 
   /**
-   * Opens the AppKit Modal to the wallet connect screen.
-   * - Ensures the UI matches the app theme
-   * - Ensures only external wallets are allowed
-   * - Ensures all existing connections are disconnected
-   * - Ensures that the network is set to mainnet (for Eth)
-   */
-  const openAppKitModalCallback = useRequiresAccountCallback(
-    async (namespace?: keyof NamespaceTypeMap) => {
-      // If previously connected, disconnect to give a "fresh" view of options
-      if (isConnected) {
-        await disconnect()
-      }
-      appkitModal.updateFeatures({ socials: false, email: false })
-      appkitModal.setThemeMode(theme.type === 'day' ? 'light' : 'dark')
-      // If the user is signed in using an external wallet, they'll be connected
-      // to the audiusChain network. Reset that to mainnet to connect properly.
-      await appkitModal.switchNetwork(mainnet)
-      await openAppKitModal({ view: 'Connect', namespace })
-      setIsAppKitModalOpen(true)
-    },
-    [disconnect, isConnected, openAppKitModal, theme.type]
-  )
-
-  /**
-   * Reconnects to the external auth wallet connector if the user wallet isn't
-   * one of the connected accounts or if the chain ID doesn't match Audius
-   */
-  const reconnectExternalAuthWallet = useCallback(async () => {
-    if (usingExternalWalletAuthRef.current && originalConnectorRef.current) {
-      const connector = originalConnectorRef.current
-      const accounts = await connector!.getAccounts()
-      const chainId = await connector!.getChainId()
-      const connectedAccountIsUserWallet =
-        accounts &&
-        accounts[0]?.toLowerCase() === currentUser?.wallet?.toLowerCase()
-      if (!connectedAccountIsUserWallet || chainId !== audiusChain.id) {
-        console.debug(
-          '[associate-wallet]',
-          'Reconnecting to external auth wallet...'
-        )
-        await connector.connect({
-          chainId: audiusChain.id
-        })
-        await switchAccountAsync({ connector })
-      }
-    }
-  }, [currentUser?.wallet, switchAccountAsync])
-
-  /**
    * Associates any Reown connected wallets to the user's account.
-   * Handles reconnecting to external wallet if used for auth.
    */
   const associateConnectedWallets = useCallback(async () => {
     try {
@@ -233,9 +162,6 @@ export const useConnectAndAssociateWallets = (
         signatures.push({ address, chain, signature })
       }
 
-      // Reconnect to original external wallet if necessary
-      await reconnectExternalAuthWallet()
-
       // Send transactions via SDK to the network to add the association
       for (const { address, chain, signature } of signatures) {
         console.debug('[associate-wallet]', 'Associating wallet...', {
@@ -262,7 +188,6 @@ export const useConnectAndAssociateWallets = (
       onError?.(e)
     } finally {
       setIsAssociating(false)
-      await reconnectExternalAuthWallet()
     }
   }, [
     addConnectedWalletAsync,
@@ -272,50 +197,37 @@ export const useConnectAndAssociateWallets = (
     make,
     onError,
     onSuccess,
-    reconnectExternalAuthWallet,
     signMessageAgnostic,
     track
   ])
 
   /**
-   * Handle events from the modal.
-   * Typical flow is:
-   * 1) SELECT_WALLET: The user has selected wallet(s) to connect
-   * 2) MODAL_CLOSE: The modal was closed (it closes automatically after selection)
-   * 3) CONNECT_SUCCESS || CONNECT_ERROR: The selected wallet(s) were connected,
-   *    or failed to connect.
+   * Handle wallet connection success and error events
    */
-  useEffect(() => {
-    return appkitModal.subscribeEvents(async (event) => {
-      // Ignore events not meant for this hook instance
-      if (!isAppKitModalOpen) return
+  const handleConnectSuccess = useCallback(async () => {
+    await associateConnectedWallets()
+  }, [associateConnectedWallets])
 
-      if (event.data.event === 'SELECT_WALLET') {
-        setIsConnecting(true)
-      } else if (event.data.event === 'MODAL_CLOSE') {
-        setIsAppKitModalOpen(false)
-        if (!isConnecting && !isAssociating) {
-          await reconnectExternalAuthWallet()
-        }
-      } else if (event.data.event === 'CONNECT_SUCCESS') {
-        setIsConnecting(false)
-        await associateConnectedWallets()
-        closeAppKitModal()
-      } else if (event.data.event === 'CONNECT_ERROR') {
-        setIsConnecting(false)
-      }
-    })
-  }, [
-    isAppKitModalOpen,
-    associateConnectedWallets,
-    reconnectExternalAuthWallet,
-    isConnecting,
-    isAssociating,
-    closeAppKitModal
-  ])
+  const handleConnectError = useCallback(
+    (event: EventsControllerState) => {
+      track(
+        make({
+          eventName: Name.CONNECT_WALLET_ERROR,
+          error: String(event.data)
+        })
+      )
+      onError?.(event)
+    },
+    [make, onError, track]
+  )
+
+  const { isPending: isConnecting, openAppKitModal } = useConnectWallets(
+    handleConnectSuccess,
+    handleConnectError
+  )
 
   return {
-    isPending: isAppKitModalOpen || isConnecting || isAssociating,
-    openAppKitModal: openAppKitModalCallback
+    isPending: isConnecting || isAssociating,
+    openAppKitModal
   }
 }

--- a/packages/web/src/hooks/useConnectWallets.ts
+++ b/packages/web/src/hooks/useConnectWallets.ts
@@ -1,0 +1,151 @@
+import { useState, useCallback, useEffect, useRef } from 'react'
+
+import { useCurrentAccountUser } from '@audius/common/api'
+import { useTheme } from '@emotion/react'
+import type { NamespaceTypeMap } from '@reown/appkit'
+import { mainnet } from '@reown/appkit/networks'
+import {
+  EventsControllerState,
+  useAppKit,
+  useDisconnect
+} from '@reown/appkit/react'
+import { useSwitchAccount, useAccount } from 'wagmi'
+
+import { appkitModal, audiusChain } from 'app/ReownAppKitModal'
+
+import { useRequiresAccountCallback } from './useRequiresAccount'
+
+/**
+ * Error when trying to associate a wallet that was already associated
+ */
+export class AlreadyAssociatedError extends Error {
+  name = 'AlreadyAssociatedError'
+}
+
+/**
+ * A wrapper around addConnectedWallet that handles actually connecting
+ * the wallets using AppKit's modal. Once AppKit fires the success event,
+ * it then gets signatures from all the connected wallets for the
+ * addConnectedWallet mutation, which it then calls for each connected wallet.
+ *
+ * - Existing connected wallets (including the auth wallet) are not re-added
+ * - The AppKit modal matches the theme and is configured properly
+ * - Works when a use is signed in using an external wallet
+ * - Handles when the user selects more than one wallet to connect at a time
+ *
+ * @param onSuccess handler for when wallets are successfully associated
+ * @param onError handler for when something goes wrong
+ *
+ * @returns a callback for opening the AppKit modal, and an `isPending` flag
+ * which is true when a wallet is in the process of being associated.
+ */
+export const useConnectWallets = (
+  onSuccess?: (wallets: EventsControllerState) => void,
+  onError?: (error: EventsControllerState) => void
+) => {
+  const theme = useTheme()
+  const { open: openAppKitModal, close: closeAppKitModal } = useAppKit()
+  const { data: currentUser } = useCurrentAccountUser()
+  const { switchAccountAsync } = useSwitchAccount()
+  const { disconnect } = useDisconnect()
+
+  // The state goes from modal open => connecting
+  // Explicitly manage our own state for the open state of the modal
+  // since there might be multiple hook instances listening for events
+  const [isConnecting, setIsConnecting] = useState(false)
+
+  // Keep track of any existing connected external wallets
+  const { isConnected, connector, chainId } = useAccount()
+  const originalConnectorRef = useRef(connector)
+  const originalChainIdRef = useRef(chainId)
+  const usingExternalWalletAuthRef = useRef(
+    !!originalConnectorRef.current &&
+      originalChainIdRef.current === audiusChain.id
+  )
+
+  /**
+   * Opens the AppKit Modal to the wallet connect screen.
+   * - Ensures the UI matches the app theme
+   * - Ensures only external wallets are allowed
+   * - Ensures all existing connections are disconnected
+   * - Ensures that the network is set to mainnet (for Eth)
+   */
+  const openAppKitModalCallback = useRequiresAccountCallback(
+    async (namespace?: keyof NamespaceTypeMap) => {
+      // If previously connected, disconnect to give a "fresh" view of options
+      if (isConnected) {
+        await disconnect()
+      }
+      appkitModal.updateFeatures({ socials: false, email: false })
+      appkitModal.setThemeMode(theme.type === 'day' ? 'light' : 'dark')
+      // If the user is signed in using an external wallet, they'll be connected
+      // to the audiusChain network. Reset that to mainnet to connect properly.
+      await appkitModal.switchNetwork(mainnet)
+      await openAppKitModal({ view: 'Connect', namespace })
+      setIsConnecting(true)
+    },
+    [disconnect, isConnected, openAppKitModal, theme.type]
+  )
+
+  /**
+   * Reconnects to the external auth wallet connector if the user wallet isn't
+   * one of the connected accounts or if the chain ID doesn't match Audius
+   */
+  const reconnectExternalAuthWallet = useCallback(async () => {
+    if (usingExternalWalletAuthRef.current && originalConnectorRef.current) {
+      const connector = originalConnectorRef.current
+      const accounts = await connector!.getAccounts()
+      const chainId = await connector!.getChainId()
+      const connectedAccountIsUserWallet =
+        accounts &&
+        accounts[0]?.toLowerCase() === currentUser?.wallet?.toLowerCase()
+      if (!connectedAccountIsUserWallet || chainId !== audiusChain.id) {
+        console.debug(
+          '[associate-wallet]',
+          'Reconnecting to external auth wallet...'
+        )
+        await connector.connect({
+          chainId: audiusChain.id
+        })
+        await switchAccountAsync({ connector })
+      }
+    }
+  }, [currentUser?.wallet, switchAccountAsync])
+  /**
+   * Handle events from the modal.
+   * Typical flow is:
+   * 1) SELECT_WALLET: The user has selected wallet(s) to connect
+   * 2) MODAL_CLOSE: The modal was closed (it closes automatically after selection)
+   * 3) CONNECT_SUCCESS || CONNECT_ERROR: The selected wallet(s) were connected,
+   *    or failed to connect.
+   */
+  useEffect(() => {
+    return appkitModal.subscribeEvents(async (event) => {
+      // Ignore events not meant for this hook instance
+      if (!isConnecting) return
+      if (event.data.event === 'MODAL_CLOSE') {
+        if (!isConnecting) {
+          await reconnectExternalAuthWallet()
+        }
+      } else if (event.data.event === 'CONNECT_SUCCESS') {
+        setIsConnecting(false)
+        await onSuccess?.(event)
+        closeAppKitModal()
+      } else if (event.data.event === 'CONNECT_ERROR') {
+        setIsConnecting(false)
+        onError?.(event)
+      }
+    })
+  }, [
+    onSuccess,
+    reconnectExternalAuthWallet,
+    isConnecting,
+    closeAppKitModal,
+    onError
+  ])
+
+  return {
+    isPending: isConnecting,
+    openAppKitModal: openAppKitModalCallback
+  }
+}

--- a/packages/web/src/hooks/useConnectWallets.ts
+++ b/packages/web/src/hooks/useConnectWallets.ts
@@ -7,7 +7,8 @@ import { mainnet } from '@reown/appkit/networks'
 import {
   EventsControllerState,
   useAppKit,
-  useDisconnect
+  useDisconnect,
+  useAppKitState
 } from '@reown/appkit/react'
 import { useSwitchAccount, useAccount } from 'wagmi'
 

--- a/packages/web/src/hooks/useConnectWallets.ts
+++ b/packages/web/src/hooks/useConnectWallets.ts
@@ -7,8 +7,7 @@ import { mainnet } from '@reown/appkit/networks'
 import {
   EventsControllerState,
   useAppKit,
-  useDisconnect,
-  useAppKitState
+  useDisconnect
 } from '@reown/appkit/react'
 import { useSwitchAccount, useAccount } from 'wagmi'
 

--- a/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
@@ -404,21 +404,25 @@ export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
   })
 
   const unclaimedFees = coin?.dynamicBondingCurve?.creatorQuoteFee ?? 0
-  const formattedUnclaimedFees = useMemo(() => {
-    const value = wAUDIO(BigInt(unclaimedFees))
+
+  const formatFeeNumber = (input: number) => {
+    const value = wAUDIO(BigInt(input))
     const decimalPlaces = getTokenDecimalPlaces(Number(value.toString()))
     return formatCurrencyWithSubscript(
-      Number(value.trunc(decimalPlaces).toString())
+      Number(value.trunc(decimalPlaces).toString()),
+      'en-US',
+      ''
     )
+  }
+  const formattedUnclaimedFees = useMemo(() => {
+    return formatFeeNumber(unclaimedFees)
   }, [unclaimedFees])
   const totalArtistEarnings =
     coin?.dynamicBondingCurve?.totalTradingQuoteFee ?? 0
-  const formattedTotalArtistEarnings = useMemo(() => {
-    // Here we divide by 2 because the artist only gets half of the fees (this value includes the AUDIO network fees)
-    const value = wAUDIO(BigInt(Math.trunc(totalArtistEarnings / 2)))
-    const decimalPlaces = getTokenDecimalPlaces(Number(value.toString()))
-    return Number(value.trunc(decimalPlaces).toString()).toString()
-  }, [totalArtistEarnings])
+  const formattedTotalArtistEarnings = useMemo(
+    () => formatFeeNumber(Math.trunc(totalArtistEarnings / 2)),
+    [totalArtistEarnings]
+  )
   const descriptionParagraphs = coin?.description?.split('\n') ?? []
 
   const openDiscord = () => {

--- a/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
@@ -474,7 +474,7 @@ export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
     const solanaAccount = appkitModal.getAccount('solana')
     const connectedAddress = solanaAccount?.address
 
-    // appkit wallet is not connected atm, need to prompt connect flow first
+    // appkit wallet is not connected, need to prompt connect flow first
     if (!connectedAddress) {
       openAppKitModal('solana')
     } else if (connectedAddress !== coinCreatorWalletAddress) {
@@ -483,7 +483,8 @@ export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
       await appkitModal.disconnect('solana')
       openAppKitModal('solana')
     } else {
-      // appkit wallet is connected with the correct address, can just initiate claim fees flow immediately
+      // appkit wallet is connected with the correct address,
+      // can just initiate claim fees flow immediately
       handleClaimFees(connectedAddress)
     }
   }, [openAppKitModal, handleClaimFees, coinCreatorWalletAddress])

--- a/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
@@ -11,6 +11,7 @@ import { useDiscordOAuthLink } from '@audius/common/hooks'
 import { coinDetailsMessages } from '@audius/common/messages'
 import { Feature, WidthSizes } from '@audius/common/models'
 import {
+  formatCurrencyWithSubscript,
   getTokenDecimalPlaces,
   removeNullable,
   route,

--- a/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
@@ -448,7 +448,7 @@ export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
     (walletAddress: string) => {
       claimFees({
         tokenMint: mint,
-        ownerWalletAddress: walletAddress
+        externalWalletAddress: walletAddress
       })
     },
     [mint, claimFees]


### PR DESCRIPTION
### Description

- Fixes the "missing solana provider" issue
- Fixes the button being grayed out because of AUDIO spl ATA not existing, now the hook will make one if necessary
- Made new useConnectWallets hook 
  - not in love with naming, open to ideas
- Refactor useConnectAndAssociateWallets hook to wrap my internal hook
- Finally figured out how to add some checks for if the user is using the correct external wallet. Feeling _much_ more comfortable with this UX for launch
![2025-10-03 21 59 20](https://github.com/user-attachments/assets/ea47613f-6e71-4965-9375-a8fe996454f1)


### How Has This Been Tested?

- Unlinked wallet entirely, working with your wallet "unassociated" 
- Claimed with a fresh account (no wAUDIO user bank)
- Deleted localStorage for everything `@appkit`, went through wallet connect flow & claimed (this is what repro'd missing solana provider issue)

TODO:
- QA the existing wallet connect spots more
- Should we add a success modal or something for claiming, and show the in app wallet balance? I can see people getting confused that it prompted them to open their external wallet but then the coins didnt get put into it