### PR TITLE
[PE-7078] Prevent user from buying too much $AUDIO

### DIFF
--- a/packages/web/src/pages/artist-coins-launchpad-page/components/LaunchpadBuyModal.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/components/LaunchpadBuyModal.tsx
@@ -42,21 +42,24 @@ import zIndex from 'utils/zIndex'
 
 import { getLastConnectedSolWallet } from '../utils'
 
-const INPUT_TOKEN_MAP: Record<string, TokenInfo & { minSwapAmount?: number }> =
-  {
-    USDC: {
-      ...TOKEN_LISTING_MAP.USDC,
-      balance: null,
-      isStablecoin: true,
-      minSwapAmount: 0.01
-    },
-    SOL: {
-      ...TOKEN_LISTING_MAP.SOL,
-      balance: null,
-      isStablecoin: false,
-      minSwapAmount: 0.000001
-    }
+const INPUT_TOKEN_MAP: Record<
+  string,
+  TokenInfo & { minSwapAmount?: number; requiredRemainingBalance?: number }
+> = {
+  USDC: {
+    ...TOKEN_LISTING_MAP.USDC,
+    balance: null,
+    isStablecoin: true,
+    minSwapAmount: 0.01
+  },
+  SOL: {
+    ...TOKEN_LISTING_MAP.SOL,
+    balance: null,
+    isStablecoin: false,
+    minSwapAmount: 0.000001,
+    requiredRemainingBalance: 0.03
   }
+}
 
 const INPUT_TOKEN_LIST = Object.values(INPUT_TOKEN_MAP)
 
@@ -404,7 +407,7 @@ export const LaunchpadBuyModal = ({
   // This is because the audio balance hook is polling, so an optimistic change here is not sufficient
   const hasAudioBalanceChanged = useMemo(() => {
     return (
-      prevAudioBalance &&
+      prevAudioBalance !== undefined &&
       audioBalance?.toString() !== prevAudioBalance?.toString()
     )
   }, [audioBalance, prevAudioBalance])
@@ -447,7 +450,8 @@ export const LaunchpadBuyModal = ({
     inputToken: selectedInputToken,
     outputToken: OUTPUT_TOKEN,
     externalWalletAddress,
-    min: selectedInputToken.minSwapAmount
+    min: selectedInputToken.minSwapAmount,
+    requiredRemainingBalance: selectedInputToken.requiredRemainingBalance
   })
 
   const [currentStep, setCurrentStep] = useState<BuyModalStep>(


### PR DESCRIPTION
### Description

Fix two subtle bugs with buy audio on launchpad flow
1. User can spend more of their sol than they would want to and then not be able to launch a coin. Therefore, we should pass an additional required minimum balance through
2. We were checking previousBalance against truthy, which means purchase when initial balance is 0 audio hang indefinitely

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Went through launch flow several times, buying audio with different amounts and starting with different balances
Also smoke tested swap flow elsewhere in the app