### PR TITLE
[PE-7105] Fix help icon not clickable on CTA

### DIFF
--- a/packages/web/src/pages/artist-coins-explore-page/ArtistCoinsExplorePage.tsx
+++ b/packages/web/src/pages/artist-coins-explore-page/ArtistCoinsExplorePage.tsx
@@ -184,19 +184,19 @@ const DesktopArtistCoinsExplorePage = () => {
                 </Flex>
 
                 {/* With absolute positioning, must be rendered after the checklist items to have higher z-index */}
-                <PlainButton
-                  iconLeft={IconQuestionCircle}
-                  asChild
-                  css={{
-                    position: 'absolute',
-                    top: spacing.l,
-                    right: spacing.l
-                  }}
-                >
-                  <ExternalLink to='https://help.audius.co/'>
+                <ExternalLink to='https://help.audius.co/'>
+                  <PlainButton
+                    iconLeft={IconQuestionCircle}
+                    asChild
+                    css={{
+                      position: 'absolute',
+                      top: spacing.l,
+                      right: spacing.l
+                    }}
+                  >
                     {messages.help}
-                  </ExternalLink>
-                </PlainButton>
+                  </PlainButton>
+                </ExternalLink>
               </Box>
             </Flex>
           </Paper>


### PR DESCRIPTION
### Description
The cause of the issue is that `<PlainButton />` wraps its children in a `<span />`. When used with a link component, this prevents the inner content of the button (the icon plus the children) from being inside the final <a/> tag that would be rendered in `<BaseButton />`. 

A quick fix for this is wrapping the `<ExternalLink />` around the `<PlainButton />` instead of the opposite. We do this in a few places already.

The _better_ fix, which I experimented with a little, is to fix `<PlainButton />` to be `asChild`-aware and not wrap in a span. However, that also removes the overflow styling and requires some other changes to make sure link styling gets applied correctly (due to an issue with style resets, our `--text-color` CSS variables don't work correctly).

Soooooo.....going to go with this for now, and then I'll open a separate PR to fix PlainButton that we can test more thoroughly and merge later.

<img width="182" height="106" alt="image" src="https://github.com/user-attachments/assets/637bea40-a57d-4ba8-9c2e-8cef3da57b27" />

### How Has This Been Tested?
`npm run:prod` and click icon in help link, make sure new tab opens to help page, etc...
