### PR TITLE
[PE-7110] Fix PlainButton link wrapping

### DIFF
--- a/packages/harmony/src/components/button/PlainButton/PlainButton.tsx
+++ b/packages/harmony/src/components/button/PlainButton/PlainButton.tsx
@@ -45,36 +45,45 @@ export const PlainButton = forwardRef<HTMLButtonElement, PlainButtonProps>(
       height: spacing.unit5
     }
 
+    const defaultTextColor =
+      variant === 'subdued' && !isDisabled
+        ? color.text.subdued
+        : variant === 'inverted'
+        ? color.static.staticWhite
+        : color.text.default
+
+    const hoverTextColor =
+      variant === 'inverted'
+        ? color.static.staticWhite
+        : color.secondary.secondary
+
+    const activeTextColor =
+      variant === 'inverted' ? color.static.staticWhite : color.secondary.s500
+
     const buttonCss: CSSObject = {
-      '--text-color':
-        variant === 'subdued' && !isDisabled
-          ? color.text.subdued
-          : variant === 'inverted'
-            ? color.static.staticWhite
-            : color.text.default,
       background: 'transparent',
       border: 'none',
-      color: 'var(--text-color)',
+      color: defaultTextColor,
       '& svg': {
-        fill: 'var(--text-color)'
+        fill: defaultTextColor
       },
       fontWeight: typography.weight.bold,
 
       ...(size === 'large' ? largeStyles : defaultStyles),
 
       '&:hover': {
-        '--text-color':
-          variant === 'inverted'
-            ? color.static.staticWhite
-            : color.secondary.secondary,
+        color: hoverTextColor,
+        '& svg': {
+          fill: hoverTextColor
+        },
         ...(variant === 'inverted' && { opacity: 0.8 })
       },
 
       '&:active': {
-        '--text-color':
-          variant === 'inverted'
-            ? color.static.staticWhite
-            : color.secondary.s500,
+        color: activeTextColor,
+        '& svg': {
+          fill: activeTextColor
+        },
         ...(variant === 'inverted' && { opacity: 0.5 })
       },
 
@@ -85,6 +94,8 @@ export const PlainButton = forwardRef<HTMLButtonElement, PlainButtonProps>(
 
     const iconCss = size === 'large' ? largeIconStyles : defaultIconStyles
 
+    // When using asChild, we don't want to wrap a span around the children
+    // as it can mess up links with icons
     return (
       <BaseButton
         ref={ref}
@@ -95,9 +106,13 @@ export const PlainButton = forwardRef<HTMLButtonElement, PlainButtonProps>(
         }}
         {...baseProps}
       >
-        <span css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-          {children}
-        </span>
+        {baseProps.asChild ? (
+          children
+        ) : (
+          <span css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {children}
+          </span>
+        )}
       </BaseButton>
     )
   }

--- a/packages/harmony/src/components/button/PlainButton/PlainButton.tsx
+++ b/packages/harmony/src/components/button/PlainButton/PlainButton.tsx
@@ -49,8 +49,8 @@ export const PlainButton = forwardRef<HTMLButtonElement, PlainButtonProps>(
       variant === 'subdued' && !isDisabled
         ? color.text.subdued
         : variant === 'inverted'
-        ? color.static.staticWhite
-        : color.text.default
+          ? color.static.staticWhite
+          : color.text.default
 
     const hoverTextColor =
       variant === 'inverted'

--- a/packages/web/src/pages/artist-coins-explore-page/ArtistCoinsExplorePage.tsx
+++ b/packages/web/src/pages/artist-coins-explore-page/ArtistCoinsExplorePage.tsx
@@ -187,19 +187,19 @@ const DesktopArtistCoinsExplorePage = () => {
                 </Flex>
 
                 {/* With absolute positioning, must be rendered after the checklist items to have higher z-index */}
-                <ExternalLink to={AUDIUS_ARTIST_COINS_HELP_LINK}>
-                  <PlainButton
-                    iconLeft={IconQuestionCircle}
-                    asChild
-                    css={{
-                      position: 'absolute',
-                      top: spacing.l,
-                      right: spacing.l
-                    }}
-                  >
+                <PlainButton
+                  iconLeft={IconQuestionCircle}
+                  asChild
+                  css={{
+                    position: 'absolute',
+                    top: spacing.l,
+                    right: spacing.l
+                  }}
+                >
+                  <ExternalLink to={AUDIUS_ARTIST_COINS_HELP_LINK}>
                     {messages.help}
-                  </PlainButton>
-                </ExternalLink>
+                  </ExternalLink>
+                </PlainButton>
               </Box>
             </Flex>
           </Paper>

--- a/packages/web/src/pages/track-page/components/shared/RemixTab.tsx
+++ b/packages/web/src/pages/track-page/components/shared/RemixTab.tsx
@@ -71,7 +71,6 @@ export const RemixTab = ({
           <PlainButton
             size={size === 'mobile' ? undefined : 'large'}
             iconRight={IconArrowRight}
-            asChild
             onClick={handleViewAllClick}
           >
             {isMobile


### PR DESCRIPTION
### Description
See original description in #13153 

* Fixes PlainButton to be asChild-aware and skip the wrapper span
* Converts color styling to not use a CSS variable. The style reset for links ends up jumping in front of it in priority. `Button` doesn't use a variable (probably for the same reason?). So I updated it to just apply `color` and `fill` directly.

### How Has This Been Tested?
Viewed all instances of `asChild` usage in `PlainButton` on local app against staging and verified they rendered correctly.
