### PR TITLE
[PE-7109] Drop ticker from coin card with balance

### DIFF
--- a/packages/mobile/src/screens/coin-details-screen/components/BalanceCard.tsx
+++ b/packages/mobile/src/screens/coin-details-screen/components/BalanceCard.tsx
@@ -101,14 +101,9 @@ const HasBalanceState = ({
             <Text variant='heading' size='s'>
               {coinName || `$${ticker}`}
             </Text>
-            <Flex row gap='xs' alignItems='center'>
-              <Text variant='title' size='l'>
-                {tokenBalanceFormatted}
-              </Text>
-              <Text variant='title' size='l' color='subdued'>
-                ${ticker}
-              </Text>
-            </Flex>
+            <Text variant='title' size='l'>
+              {tokenBalanceFormatted}
+            </Text>
           </Flex>
         </Flex>
         <Flex row alignItems='center' gap='m' ml={spacing.unit22}>


### PR DESCRIPTION
### Description

Drops the ticker in the balance section since there will often be overflow. The ticker is in the header so i think we are good