### PR TITLE
[PE-6947] Fix buy/sell/swap optimistic updates

### DIFF
--- a/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
+++ b/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
@@ -198,7 +198,8 @@ export const useAudioBalance = (
         ...(data?.spl_wallet
           ? [{ address: data.spl_wallet, chain: Chain.Sol }]
           : [])
-      ]
+      ],
+      includeStaked
     },
     { ...options, enabled: isUserFetched }
   )

--- a/packages/common/src/hooks/useFormattedAudioBalance.ts
+++ b/packages/common/src/hooks/useFormattedAudioBalance.ts
@@ -21,9 +21,15 @@ type UseFormattedAudioBalanceReturn = {
   formattedHeldValue: string | null
 }
 
-export const useFormattedAudioBalance = (): UseFormattedAudioBalanceReturn => {
+export const useFormattedAudioBalance = ({
+  includeStaked = false
+}: {
+  includeStaked?: boolean
+} = {}): UseFormattedAudioBalanceReturn => {
   const { env } = useQueryContext()
-  const { totalBalance, isLoading: isAudioBalanceLoading } = useAudioBalance()
+  const { totalBalance, isLoading: isAudioBalanceLoading } = useAudioBalance({
+    includeStaked
+  })
 
   const { data: audioPriceData, isPending: isAudioPriceLoading } =
     useArtistCoin(env.WAUDIO_MINT_ADDRESS)

--- a/packages/common/src/store/ui/buy-sell/useBuySellSwap.ts
+++ b/packages/common/src/store/ui/buy-sell/useBuySellSwap.ts
@@ -126,11 +126,6 @@ export const useBuySellSwap = (props: UseBuySellSwapProps) => {
         }
       })
     }
-    if (user?.spl_wallet) {
-      queryClient.invalidateQueries({
-        queryKey: [QUERY_KEYS.audioBalance, user.spl_wallet]
-      })
-    }
   }
 
   const handleShowConfirmation = useCallback(() => {

--- a/packages/mobile/src/screens/wallet-screen/components/AudioCoinCard.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/AudioCoinCard.tsx
@@ -2,18 +2,18 @@ import { useCallback } from 'react'
 
 import { useFormattedAudioBalance } from '@audius/common/hooks'
 import { AUDIO_TICKER, TOKEN_LISTING_MAP } from '@audius/common/store'
-import { Image } from 'react-native'
+import { TouchableOpacity } from 'react-native-gesture-handler'
 
 import {
   Box,
   Flex,
   HexagonalIcon,
+  IconTokenAUDIO,
   Skeleton,
   spacing,
   Text
 } from '@audius/harmony-native'
 import { useNavigation } from 'app/hooks/useNavigation'
-import { TouchableOpacity } from 'react-native-gesture-handler'
 
 const ICON_SIZE = 64
 
@@ -55,23 +55,6 @@ export const AudioCoinCard = () => {
   }, [navigation])
 
   const isLoading = isAudioBalanceLoading || isAudioPriceLoading
-  const logoURI = TOKEN_LISTING_MAP.AUDIO.logoURI
-
-  const renderIcon = () => {
-    return (
-      <HexagonalIcon size={ICON_SIZE}>
-        <Image
-          source={
-            typeof logoURI === 'string' ? { uri: logoURI } : (logoURI as number)
-          }
-          style={{
-            width: ICON_SIZE,
-            height: ICON_SIZE
-          }}
-        />
-      </HexagonalIcon>
-    )
-  }
 
   return (
     <TouchableOpacity onPress={onPress}>
@@ -83,7 +66,7 @@ export const AudioCoinCard = () => {
         alignItems='center'
       >
         <Flex row alignItems='center' gap='l' style={{ flexShrink: 1 }}>
-          {isLoading ? <AudioHexagonalSkeleton /> : renderIcon()}
+          {isLoading ? <AudioHexagonalSkeleton /> : <IconTokenAUDIO />}
           <Flex column gap='xs'>
             {isLoading ? (
               <AudioCoinCardSkeleton />
@@ -104,7 +87,7 @@ export const AudioCoinCard = () => {
                   style={{ maxWidth: '100%' }}
                 >
                   <Text variant='title' size='l'>
-                    {audioBalanceFormatted ?? '0'}
+                    {audioBalanceFormatted}
                   </Text>
                   <Text
                     variant='title'
@@ -124,7 +107,7 @@ export const AudioCoinCard = () => {
         <Flex row alignItems='center' gap='m' ml={spacing.unit22}>
           {!isLoading ? (
             <Text variant='title' size='l' color='default'>
-              {formattedHeldValue ?? '$0.00'}
+              {formattedHeldValue}
             </Text>
           ) : null}
         </Flex>

--- a/packages/mobile/src/screens/wallet-screen/components/AudioCoinCard.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/AudioCoinCard.tsx
@@ -1,0 +1,134 @@
+import { useCallback } from 'react'
+
+import { useFormattedAudioBalance } from '@audius/common/hooks'
+import { AUDIO_TICKER, TOKEN_LISTING_MAP } from '@audius/common/store'
+import { Image } from 'react-native'
+
+import {
+  Box,
+  Flex,
+  HexagonalIcon,
+  Skeleton,
+  spacing,
+  Text
+} from '@audius/harmony-native'
+import { useNavigation } from 'app/hooks/useNavigation'
+import { TouchableOpacity } from 'react-native-gesture-handler'
+
+const ICON_SIZE = 64
+
+export const AudioCoinCardSkeleton = () => {
+  return (
+    <Flex column gap='xs'>
+      <Box w={240} h={36}>
+        <Skeleton />
+      </Box>
+      <Box w={140} h={24}>
+        <Skeleton />
+      </Box>
+    </Flex>
+  )
+}
+
+export const AudioHexagonalSkeleton = () => {
+  return (
+    <HexagonalIcon size={ICON_SIZE}>
+      <Box w={ICON_SIZE} h={ICON_SIZE}>
+        <Skeleton />
+      </Box>
+    </HexagonalIcon>
+  )
+}
+
+export const AudioCoinCard = () => {
+  const navigation = useNavigation()
+
+  const {
+    audioBalanceFormatted,
+    isAudioBalanceLoading,
+    isAudioPriceLoading,
+    formattedHeldValue
+  } = useFormattedAudioBalance()
+
+  const onPress = useCallback(() => {
+    navigation.navigate('AudioScreen')
+  }, [navigation])
+
+  const isLoading = isAudioBalanceLoading || isAudioPriceLoading
+  const logoURI = TOKEN_LISTING_MAP.AUDIO.logoURI
+
+  const renderIcon = () => {
+    return (
+      <HexagonalIcon size={ICON_SIZE}>
+        <Image
+          source={
+            typeof logoURI === 'string' ? { uri: logoURI } : (logoURI as number)
+          }
+          style={{
+            width: ICON_SIZE,
+            height: ICON_SIZE
+          }}
+        />
+      </HexagonalIcon>
+    )
+  }
+
+  return (
+    <TouchableOpacity onPress={onPress}>
+      <Flex
+        p='l'
+        pl='xl'
+        row
+        justifyContent='space-between'
+        alignItems='center'
+      >
+        <Flex row alignItems='center' gap='l' style={{ flexShrink: 1 }}>
+          {isLoading ? <AudioHexagonalSkeleton /> : renderIcon()}
+          <Flex column gap='xs'>
+            {isLoading ? (
+              <AudioCoinCardSkeleton />
+            ) : (
+              <>
+                <Text
+                  variant='heading'
+                  size='s'
+                  numberOfLines={1}
+                  ellipsizeMode='tail'
+                >
+                  {TOKEN_LISTING_MAP.AUDIO.name}
+                </Text>
+                <Flex
+                  row
+                  alignItems='center'
+                  gap='xs'
+                  style={{ maxWidth: '100%' }}
+                >
+                  <Text variant='title' size='l'>
+                    {audioBalanceFormatted ?? '0'}
+                  </Text>
+                  <Text
+                    variant='title'
+                    size='l'
+                    color='subdued'
+                    numberOfLines={1}
+                    ellipsizeMode='tail'
+                    style={{ flexShrink: 1 }}
+                  >
+                    ${AUDIO_TICKER}
+                  </Text>
+                </Flex>
+              </>
+            )}
+          </Flex>
+        </Flex>
+        <Flex row alignItems='center' gap='m' ml={spacing.unit22}>
+          {!isLoading ? (
+            <Text variant='title' size='l' color='default'>
+              {formattedHeldValue ?? '$0.00'}
+            </Text>
+          ) : null}
+        </Flex>
+      </Flex>
+    </TouchableOpacity>
+  )
+}

--- a/packages/mobile/src/screens/wallet-screen/components/YourCoins.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/YourCoins.tsx
@@ -15,6 +15,7 @@ import { TouchableOpacity } from 'react-native'
 import { Box, Button, Divider, Flex, Paper, Text } from '@audius/harmony-native'
 import { useNavigation } from 'app/hooks/useNavigation'
 
+import { AudioCoinCard } from './AudioCoinCard'
 import { CoinCard, CoinCardSkeleton, HexagonalSkeleton } from './CoinCard'
 
 const messages = {
@@ -122,7 +123,7 @@ export const YourCoins = () => {
               {item === 'discover-artist-coins' ? (
                 <DiscoverArtistCoinsCard onPress={handleDiscoverArtistCoins} />
               ) : item === 'audio-coin' ? (
-                <CoinCard mint={env.WAUDIO_MINT_ADDRESS} />
+                <AudioCoinCard />
               ) : (
                 <CoinCard mint={item.mint} />
               )}


### PR DESCRIPTION
### Description
Now that we've split off $AUDIO balances into their own separate query key space, we need to include optimistic updates for those query keys.

Unfortunately it seems like different places in the app use both `includeStaked: true` or `false` so we have to update both. Annoying but I think it's correct?

### How Has This Been Tested?


https://github.com/user-attachments/assets/420949bb-0836-4181-b4a5-63dcadf50b28

