### PR TITLE
[PE-7114] Use buy/sell even if not enough balance

### DIFF
--- a/packages/common/src/store/ui/modals/add-cash-modal/index.ts
+++ b/packages/common/src/store/ui/modals/add-cash-modal/index.ts
@@ -2,6 +2,7 @@ import { createModal } from '../createModal'
 
 export type AddCashModalState = {
   isOpen: boolean
+  portalHostName?: string
 }
 
 const AddCashModal = createModal<AddCashModalState>({

--- a/packages/mobile/src/components/add-funds-drawer/AddCashDrawer.tsx
+++ b/packages/mobile/src/components/add-funds-drawer/AddCashDrawer.tsx
@@ -4,6 +4,7 @@ import { DEFAULT_PURCHASE_AMOUNT_CENTS } from '@audius/common/hooks'
 import { walletMessages } from '@audius/common/messages'
 import { PurchaseMethod, PurchaseVendor } from '@audius/common/models'
 import { buyUSDCActions, useAddCashModal } from '@audius/common/store'
+import { Portal } from '@gorhom/portal'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { Button, Flex, Text } from '@audius/harmony-native'
@@ -29,7 +30,12 @@ const messages = {
 export const AddCashDrawer = () => {
   const dispatch = useDispatch()
   const purchaseVendorState = useSelector(getPurchaseVendor)
-  const { isOpen, onClose, onClosed } = useAddCashModal()
+  const {
+    isOpen,
+    onClose,
+    onClosed,
+    data: { portalHostName }
+  } = useAddCashModal()
 
   const [selectedPurchaseMethod, setSelectedPurchaseMethod] =
     useState<PurchaseMethod>(PurchaseMethod.CARD)
@@ -59,7 +65,7 @@ export const AddCashDrawer = () => {
     onClose()
   }, [dispatch, onClose])
 
-  return (
+  const content = (
     <Drawer isOpen={isOpen} onClose={handleClose} onClosed={onClosed}>
       <Flex gap='xl' pb='xl'>
         {page === AddCashDrawerPage.MAIN ? (
@@ -102,5 +108,11 @@ export const AddCashDrawer = () => {
         )}
       </Flex>
     </Drawer>
+  )
+
+  return portalHostName ? (
+    <Portal hostName={portalHostName}>{content}</Portal>
+  ) : (
+    content
   )
 }

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx
@@ -303,7 +303,10 @@ export const BuySellFlow = ({
   ])
 
   const handleAddCash = useCallback(() => {
-    openAddCashModal()
+    openAddCashModal({
+      isOpen: true,
+      portalHostName: 'BuySellModalScreenDrawerPortal'
+    })
     trackAddFundsClicked('insufficient_balance_hint')
   }, [openAddCashModal, trackAddFundsClicked])
 

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellModalScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellModalScreen.tsx
@@ -1,4 +1,5 @@
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet'
+import { PortalHost } from '@gorhom/portal'
 import { useRoute } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 
@@ -38,6 +39,7 @@ export const BuySellModalScreen = () => {
             options={{ gestureEnabled: false, headerLeft: () => null }}
           />
         </Stack.Navigator>
+        <PortalHost name='BuySellModalScreenDrawerPortal' />
       </BottomSheetModalProvider>
     </ModalScreen>
   )

--- a/packages/web/src/pages/asset-detail-page/components/BalanceSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/BalanceSection.tsx
@@ -3,8 +3,7 @@ import { useCallback, useState } from 'react'
 import {
   useArtistCoin,
   useCurrentAccountUser,
-  useTokenBalance,
-  useUSDCBalance
+  useTokenBalance
 } from '@audius/common/api'
 import {
   useFormattedTokenBalance,
@@ -12,7 +11,6 @@ import {
 } from '@audius/common/hooks'
 import { walletMessages } from '@audius/common/messages'
 import {
-  useAddCashModal,
   useBuySellModal,
   useReceiveTokensModal,
   useSendTokensModal
@@ -263,13 +261,10 @@ const BalanceSectionContent = ({ mint }: AssetDetailProps) => {
     useTokenBalance({ mint })
   const { data: currentUser } = useCurrentAccountUser()
 
-  const { data: usdcBalance } = useUSDCBalance()
-
   const { isBuySellSupported } = useBuySellRegionSupport()
 
   // Modal hooks
   const { onOpen: openBuySellModal } = useBuySellModal()
-  const { onOpen: openAddCashModal } = useAddCashModal()
   const [, openTransferDrawer] = useModalState('TransferAudioMobileWarning')
   const { onOpen: openReceiveTokensModal } = useReceiveTokensModal()
   const { onOpen: openSendTokensModal } = useSendTokensModal()
@@ -292,14 +287,8 @@ const BalanceSectionContent = ({ mint }: AssetDetailProps) => {
   }, [openBuySellModal])
 
   const handleAddCash = useRequiresAccountCallback(() => {
-    if (usdcBalance && usdcBalance > 0) {
-      // Has USDC balance - show buy/sell modal
-      openBuySellModal()
-    } else {
-      // No USDC balance - show add cash modal (uses Coinflow)
-      openAddCashModal()
-    }
-  }, [openAddCashModal, openBuySellModal, usdcBalance])
+    openBuySellModal()
+  }, [openBuySellModal])
 
   const handleReceive = useRequiresAccountCallback(() => {
     openReceiveTokensModal({


### PR DESCRIPTION
### Description

Uses buy/sell instead of add funds, even if zero balance.

Also fix bug in mobile where buy/sell doesn't let you add funds because the drawer shows below. This was due to the way our stack hierarchy is. Fixing it by adding an optional portal host to pass to the modal state, which can be used to anchor the drawer elsewhere. We have sort of done this pattern before (there's an existing PortalHost for drawers in the top level in App.tsx)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Web:
* No usdc balance
* Click buy on artist coin

Mobile:
* Tried add funds from buy/sell and can see it
<img width="200" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-05 at 20 38 23" src="https://github.com/user-attachments/assets/fada2597-b68f-430d-8ab4-a8f0666d0b5d" />

* Tried add funds from wallet page and can see it

