### PR TITLE
[PE-7116|PE-7117] Refactor explore pagination & add mobile token ticker filter

### DIFF
--- a/packages/common/src/api/tan-query/coins/useArtistCoins.ts
+++ b/packages/common/src/api/tan-query/coins/useArtistCoins.ts
@@ -1,5 +1,11 @@
 import { GetCoinsSortMethodEnum, GetCoinsSortDirectionEnum } from '@audius/sdk'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  useQuery,
+  useInfiniteQuery,
+  useQueryClient,
+  type InfiniteData,
+  type UseInfiniteQueryOptions
+} from '@tanstack/react-query'
 
 import { coinListFromSDK, Coin } from '~/adapters/coin'
 
@@ -9,7 +15,7 @@ import { useQueryContext } from '../utils/QueryContext'
 
 import { getArtistCoinQueryKey } from './useArtistCoin'
 
-export type UseArtistCoinsParams = {
+export type UseArtistCoinsListParams = {
   limit?: number
   offset?: number
   sortMethod?: GetCoinsSortMethodEnum
@@ -17,18 +23,18 @@ export type UseArtistCoinsParams = {
   query?: string
 }
 
-export const getArtistCoinsQueryKey = (params?: UseArtistCoinsParams) =>
+export const getArtistCoinsListQueryKey = (params?: UseArtistCoinsListParams) =>
   [QUERY_KEYS.coins, 'list', params] as unknown as QueryKey<Coin[]>
 
-export const useArtistCoins = <TResult = Coin[]>(
-  params: UseArtistCoinsParams = {},
+export const useArtistCoinsList = <TResult = Coin[]>(
+  params: UseArtistCoinsListParams = {},
   options?: SelectableQueryOptions<Coin[], TResult>
 ) => {
   const { audiusSdk } = useQueryContext()
   const queryClient = useQueryClient()
 
   return useQuery({
-    queryKey: getArtistCoinsQueryKey(params),
+    queryKey: getArtistCoinsListQueryKey(params),
     queryFn: async () => {
       const sdk = await audiusSdk()
 
@@ -56,6 +62,77 @@ export const useArtistCoins = <TResult = Coin[]>(
     },
     ...options,
     enabled: options?.enabled !== false
+  })
+}
+
+export type UseArtistCoinsParams = {
+  pageSize?: number
+  sortMethod?: GetCoinsSortMethodEnum
+  sortDirection?: GetCoinsSortDirectionEnum
+  query?: string
+}
+
+export const getArtistCoinsQueryKey = (params?: UseArtistCoinsParams) =>
+  [QUERY_KEYS.coins, 'infinite', params] as unknown as QueryKey<
+    InfiniteData<Coin[], number>
+  >
+
+export const useArtistCoins = (
+  params: UseArtistCoinsParams = {},
+  options?: Omit<
+    UseInfiniteQueryOptions<
+      Coin[],
+      Error,
+      InfiniteData<Coin[], number>,
+      Coin[],
+      QueryKey<InfiniteData<Coin[], number>>,
+      number
+    >,
+    'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
+  >
+) => {
+  const { audiusSdk } = useQueryContext()
+  const queryClient = useQueryClient()
+  const pageSize = params.pageSize ?? 10
+
+  return useInfiniteQuery({
+    queryKey: getArtistCoinsQueryKey(params),
+    queryFn: async ({ pageParam = 0 }) => {
+      const sdk = await audiusSdk()
+
+      const response = await sdk.coins.getCoins({
+        limit: pageSize,
+        offset: pageParam,
+        sortMethod: params.sortMethod,
+        sortDirection: params.sortDirection,
+        query: params.query
+      })
+
+      const coins = response?.data
+      const parsedCoins = coinListFromSDK(coins)
+
+      // Prime individual coin data for each mint
+      if (parsedCoins) {
+        parsedCoins.forEach((coin) => {
+          if (coin.mint) {
+            queryClient.setQueryData(getArtistCoinQueryKey(coin.mint), coin)
+          }
+        })
+      }
+
+      return parsedCoins ?? []
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      // If the last page has fewer items than the page size, we've reached the end
+      if (lastPage.length < pageSize) {
+        return undefined
+      }
+      // Otherwise, return the next offset
+      return allPages.length * pageSize
+    },
+    enabled: options?.enabled !== false,
+    ...options
   })
 }
 

--- a/packages/common/src/api/tan-query/coins/useArtistCoins.ts
+++ b/packages/common/src/api/tan-query/coins/useArtistCoins.ts
@@ -93,7 +93,7 @@ export const useArtistCoins = (
 ) => {
   const { audiusSdk } = useQueryContext()
   const queryClient = useQueryClient()
-  const pageSize = params.pageSize ?? 10
+  const pageSize = params.pageSize ?? 25
 
   return useInfiniteQuery({
     queryKey: getArtistCoinsQueryKey(params),

--- a/packages/common/src/api/tan-query/coins/useArtistCoins.ts
+++ b/packages/common/src/api/tan-query/coins/useArtistCoins.ts
@@ -83,12 +83,12 @@ export const useArtistCoins = (
     UseInfiniteQueryOptions<
       Coin[],
       Error,
-      InfiniteData<Coin[], number>,
+      Coin[],
       Coin[],
       QueryKey<InfiniteData<Coin[], number>>,
       number
     >,
-    'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
+    'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam' | 'select'
   >
 ) => {
   const { audiusSdk } = useQueryContext()
@@ -132,6 +132,7 @@ export const useArtistCoins = (
       return allPages.length * pageSize
     },
     enabled: options?.enabled !== false,
+    select: (data) => data.pages.flat(),
     ...options
   })
 }

--- a/packages/common/src/api/tan-query/coins/useArtistCoins.ts
+++ b/packages/common/src/api/tan-query/coins/useArtistCoins.ts
@@ -23,6 +23,8 @@ export type UseArtistCoinsListParams = {
   query?: string
 }
 
+const DEFAULT_PAGE_SIZE = 25
+
 export const getArtistCoinsListQueryKey = (params?: UseArtistCoinsListParams) =>
   [QUERY_KEYS.coins, 'list', params] as unknown as QueryKey<Coin[]>
 
@@ -93,7 +95,7 @@ export const useArtistCoins = (
 ) => {
   const { audiusSdk } = useQueryContext()
   const queryClient = useQueryClient()
-  const pageSize = params.pageSize ?? 25
+  const pageSize = params.pageSize ?? DEFAULT_PAGE_SIZE
 
   return useInfiniteQuery({
     queryKey: getArtistCoinsQueryKey(params),

--- a/packages/mobile/src/screens/artist-coins-explore-screen/ArtistCoinsExploreScreen.tsx
+++ b/packages/mobile/src/screens/artist-coins-explore-screen/ArtistCoinsExploreScreen.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 
 import type { Coin } from '@audius/common/adapters'
 import {
@@ -35,7 +35,6 @@ import { env } from 'app/services/env'
 
 import { GradientText, TokenIcon, Screen } from '../../components/core'
 
-const PAGE_SIZE = 50
 const COIN_ROW_HEIGHT = 50 // Estimated height for FlashList optimization
 
 type CoinRowProps = {
@@ -131,10 +130,6 @@ export const ArtistCoinsExploreScreen = () => {
   const [sortDirection, setSortDirection] = useState<GetCoinsSortDirectionEnum>(
     GetCoinsSortDirectionEnum.Desc
   )
-  const [offset, setOffset] = useState(0)
-  const [allCoins, setAllCoins] = useState<Coin[]>([])
-  const [hasMore, setHasMore] = useState(true)
-  const [isLoadingNewSearch, setIsLoadingNewSearch] = useState(false)
 
   // Set status bar to light content for dark header
   useStatusBarStyle('light-content')
@@ -143,53 +138,32 @@ export const ArtistCoinsExploreScreen = () => {
   useDebounce(
     () => {
       setDebouncedSearchValue(searchValue)
-      setIsLoadingNewSearch(false)
     },
     300,
     [searchValue]
   )
 
   const {
-    data: coinsData,
+    data,
     isPending,
-    isFetching
+    isFetching,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage
   } = useArtistCoins({
     sortMethod,
     sortDirection,
-    query: debouncedSearchValue,
-    limit: PAGE_SIZE,
-    offset
+    query: debouncedSearchValue
   })
+  console.log({ isFetchingNextPage })
 
-  // Accumulate coins when new data arrives
-  useEffect(() => {
-    if (coinsData) {
-      const filteredCoins = coinsData.filter(
-        (coin) => coin.mint !== env.WAUDIO_MINT_ADDRESS
-      )
-
-      if (offset === 0) {
-        // First page - replace all coins
-        setAllCoins(filteredCoins)
-      } else {
-        // Subsequent pages - append new coins
-        setAllCoins((prev) => [...prev, ...filteredCoins])
-      }
-
-      // Check if we have more data
-      setHasMore(filteredCoins.length > 0)
-    }
-  }, [coinsData, offset])
-
-  // Reset pagination when search or sort changes
-  useEffect(() => {
-    setOffset(0)
-    setAllCoins([])
-    setHasMore(true)
-    setIsLoadingNewSearch(true)
-  }, [searchValue, sortMethod, sortDirection])
-
-  const coins = allCoins
+  // Flatten all pages and filter out WAUDIO
+  const allCoins = useMemo(() => {
+    if (!data?.pages) return []
+    return data.pages
+      .flat()
+      .filter((coin) => coin.mint !== env.WAUDIO_MINT_ADDRESS)
+  }, [data?.pages])
 
   const handleCoinPress = useCallback(
     (ticker?: string) => {
@@ -208,10 +182,10 @@ export const ArtistCoinsExploreScreen = () => {
   }, [navigation, sortMethod, sortDirection])
 
   const handleLoadMore = useCallback(() => {
-    if (!isFetching && hasMore && coinsData && coinsData.length === PAGE_SIZE) {
-      setOffset((prev) => prev + PAGE_SIZE)
+    if (!isFetchingNextPage && hasNextPage) {
+      fetchNextPage()
     }
-  }, [isFetching, hasMore, coinsData])
+  }, [isFetchingNextPage, hasNextPage, fetchNextPage])
 
   useEffect(() => {
     const routeParams = route.params as any
@@ -224,7 +198,7 @@ export const ArtistCoinsExploreScreen = () => {
   }, [route.params])
 
   const shouldShowNoCoinsContent =
-    !isPending && !isFetching && !isLoadingNewSearch && coins.length === 0
+    !isPending && !isFetching && allCoins.length === 0
 
   const renderCoinRow: ListRenderItem<Coin> = useCallback(
     ({ item }) => (
@@ -236,7 +210,7 @@ export const ArtistCoinsExploreScreen = () => {
   const keyExtractor = useCallback((coin: Coin) => coin.mint, [])
 
   const renderFooter = useCallback(() => {
-    if (isFetching && offset > 0) {
+    if (isFetchingNextPage) {
       return (
         <Flex justifyContent='center' alignItems='center' p='l'>
           <LoadingSpinner />
@@ -244,8 +218,7 @@ export const ArtistCoinsExploreScreen = () => {
       )
     }
     return null
-  }, [isFetching, offset])
-
+  }, [isFetchingNextPage])
   return (
     <Screen
       header={() => (
@@ -281,7 +254,7 @@ export const ArtistCoinsExploreScreen = () => {
           </TouchableOpacity>
         </Flex>
         <Divider orientation='horizontal' />
-        {(isPending && offset === 0) || isLoadingNewSearch ? (
+        {isPending ? (
           <Flex justifyContent='center' alignItems='center' p='4xl'>
             <LoadingSpinner />
           </Flex>
@@ -289,7 +262,7 @@ export const ArtistCoinsExploreScreen = () => {
           <NoCoinsContent />
         ) : (
           <FlashList
-            data={coins}
+            data={allCoins}
             renderItem={renderCoinRow}
             keyExtractor={keyExtractor}
             estimatedItemSize={COIN_ROW_HEIGHT}

--- a/packages/mobile/src/screens/artist-coins-explore-screen/ArtistCoinsExploreScreen.tsx
+++ b/packages/mobile/src/screens/artist-coins-explore-screen/ArtistCoinsExploreScreen.tsx
@@ -155,7 +155,6 @@ export const ArtistCoinsExploreScreen = () => {
     sortDirection,
     query: debouncedSearchValue
   })
-  console.log({ isFetchingNextPage })
 
   // Flatten all pages and filter out WAUDIO
   const allCoins = useMemo(() => {

--- a/packages/mobile/src/screens/artist-coins-explore-screen/ArtistCoinsExploreScreen.tsx
+++ b/packages/mobile/src/screens/artist-coins-explore-screen/ArtistCoinsExploreScreen.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 
 import type { Coin } from '@audius/common/adapters'
 import {
@@ -144,7 +144,7 @@ export const ArtistCoinsExploreScreen = () => {
   )
 
   const {
-    data,
+    data: coins,
     isPending,
     isFetching,
     fetchNextPage,
@@ -156,13 +156,9 @@ export const ArtistCoinsExploreScreen = () => {
     query: debouncedSearchValue
   })
 
-  // Flatten all pages and filter out WAUDIO
-  const allCoins = useMemo(() => {
-    if (!data?.pages) return []
-    return data.pages
-      .flat()
-      .filter((coin) => coin.mint !== env.WAUDIO_MINT_ADDRESS)
-  }, [data?.pages])
+  // Filter out WAUDIO
+  const allCoins =
+    coins?.filter((coin) => coin.mint !== env.WAUDIO_MINT_ADDRESS) ?? []
 
   const handleCoinPress = useCallback(
     (ticker?: string) => {

--- a/packages/mobile/src/screens/list-selection-screen/ListSelectionScreen.tsx
+++ b/packages/mobile/src/screens/list-selection-screen/ListSelectionScreen.tsx
@@ -78,9 +78,10 @@ export const ListSelectionScreen = (props: ListSelectionProps) => {
 
   const styles = useStyles()
   const [filterInput, setFilterInput] = useState('')
-  const filterRegexp = new RegExp(filterInput, 'i')
-  const filteredData = data.filter(({ label, value }) =>
-    (label ?? value).match(filterRegexp)
+  const filterRegexp = new RegExp(filterInput, 'ig')
+  const filteredData = [...data].filter(
+    ({ label, value }) =>
+      label?.match(filterRegexp) || value?.match(filterRegexp)
   )
 
   return (


### PR DESCRIPTION
### Description

- Refactors useArtistCoins to `useInfiniteQuery` rather than paginate in-component
- Updates web & mobile callsites to use new patterns
- Fixes pagination logic leading to infinite spinner on coin discovery page on mobile
- Fixes token filter not including ticker (e.g. trying to find Goblin Coin / MAGICBAD via "magic")

### How Has This Been Tested?

web:prod
ios:prod
- Tested as many states of filtering/sorting on explore that I can think of
- Tested token filtering