### PR TITLE
[PE-7043][PE-7096] Some refactoring for buy/sell keyboard avoidance

### DIFF
--- a/packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx
@@ -20,6 +20,7 @@ import {
   useTokenStates
 } from '@audius/common/store'
 import { useFocusEffect } from '@react-navigation/native'
+import { InteractionManager, Keyboard } from 'react-native'
 
 import { Button, Flex, Hint, TextLink } from '@audius/harmony-native'
 import { SegmentedControl } from 'app/components/core'
@@ -64,6 +65,14 @@ export const BuySellFlow = ({
     resetTransactionData,
     initialTab
   })
+
+  const handleTabChange = (newTab: BuySellTab) => {
+    handleActiveTabChange(newTab)
+    // Dismiss keyboard in case we were focused on an input
+    InteractionManager.runAfterInteractions(() => {
+      Keyboard.dismiss()
+    })
+  }
 
   // Use custom hooks for token state management
   const {
@@ -322,7 +331,7 @@ export const BuySellFlow = ({
           <SegmentedControl
             options={tabs}
             selected={activeTab}
-            onSelectOption={handleActiveTabChange}
+            onSelectOption={handleTabChange}
             fullWidth
           />
         </Flex>

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellScreen.tsx
@@ -1,7 +1,6 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import { buySellMessages as messages } from '@audius/common/messages'
-import { useKeyboard } from '@react-native-community/hooks'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import { Flex } from '@audius/harmony-native'
@@ -9,9 +8,10 @@ import {
   Screen,
   ScreenContent,
   FixedFooter,
-  ScrollView
+  ScrollView,
+  KeyboardAvoidingView
 } from 'app/components/core'
-import { FIXED_FOOTER_HEIGHT } from 'app/components/core/FixedFooter'
+// import { FIXED_FOOTER_HEIGHT } from 'app/components/core/FixedFooter'
 import { useNavigation } from 'app/hooks/useNavigation'
 
 import type { BuySellScreenParams } from '../../types/navigation'
@@ -29,7 +29,7 @@ export const BuySellScreen = ({ route }: BuySellScreenProps) => {
   const navigation = useNavigation()
   const { params } = route
   const insets = useSafeAreaInsets()
-  const { keyboardHeight, keyboardShown } = useKeyboard()
+  // const { keyboardHeight, keyboardShown } = useKeyboard()
 
   const handleClose = () => {
     navigation.goBack()
@@ -41,35 +41,36 @@ export const BuySellScreen = ({ route }: BuySellScreenProps) => {
     coinTicker: params?.coinTicker
   })
 
-  const dynamicPaddingBottom = useMemo(() => {
-    // We need to account for the FixedFooter's height and the safe area insets.
-    // Additionally, when the keyboard is shown, we need to add the keyboard height
-    // so the content scrolls above the keyboard.
-    return (
-      FIXED_FOOTER_HEIGHT + insets.bottom + (keyboardShown ? keyboardHeight : 0)
-    )
-  }, [insets.bottom, keyboardHeight, keyboardShown])
-
+  // We need to account for the FixedFooter's height and the safe area insets.
+  // Additionally, when the keyboard is shown, we need to add the keyboard height
+  // so the content scrolls above the keyboard.
+  // const dynamicPaddingBottom =
+  //   insets.bottom + (keyboardShown ? keyboardHeight : 0)
   return (
     <Screen title={messages.title} variant='white' url='/buy-sell'>
       <ScreenContent>
         <ScrollView
           style={{ flex: 1 }}
           contentContainerStyle={{
-            flexGrow: 1,
-            paddingBottom: dynamicPaddingBottom
+            flexGrow: 1
           }}
           keyboardShouldPersistTaps='handled'
           showsVerticalScrollIndicator={false}
         >
-          <PoweredByJupiter />
-          <Flex mt='xl' p='l'>
-            {flowData.content}
-          </Flex>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior='padding'
+            keyboardShowingOffset={insets.bottom}
+          >
+            <PoweredByJupiter />
+            <Flex mt='xl' p='l'>
+              {flowData.content}
+            </Flex>
+          </KeyboardAvoidingView>
         </ScrollView>
-
-        <FixedFooter avoidKeyboard>{flowData.footer}</FixedFooter>
+        <FixedFooter>{flowData.footer}</FixedFooter>
       </ScreenContent>
+      {/* <FixedFooter avoidKeyboard>{flowData.footer}</FixedFooter> */}
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellScreen.tsx
@@ -1,17 +1,18 @@
 import React from 'react'
 
 import { buySellMessages as messages } from '@audius/common/messages'
+import { css } from '@emotion/native'
+import { Platform } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
-import { Flex } from '@audius/harmony-native'
+import { Flex, Paper, spacing } from '@audius/harmony-native'
 import {
   Screen,
   ScreenContent,
-  FixedFooter,
   ScrollView,
   KeyboardAvoidingView
 } from 'app/components/core'
-// import { FIXED_FOOTER_HEIGHT } from 'app/components/core/FixedFooter'
+import { FIXED_FOOTER_HEIGHT } from 'app/components/core/FixedFooter'
 import { useNavigation } from 'app/hooks/useNavigation'
 
 import type { BuySellScreenParams } from '../../types/navigation'
@@ -29,7 +30,6 @@ export const BuySellScreen = ({ route }: BuySellScreenProps) => {
   const navigation = useNavigation()
   const { params } = route
   const insets = useSafeAreaInsets()
-  // const { keyboardHeight, keyboardShown } = useKeyboard()
 
   const handleClose = () => {
     navigation.goBack()
@@ -41,18 +41,18 @@ export const BuySellScreen = ({ route }: BuySellScreenProps) => {
     coinTicker: params?.coinTicker
   })
 
-  // We need to account for the FixedFooter's height and the safe area insets.
-  // Additionally, when the keyboard is shown, we need to add the keyboard height
-  // so the content scrolls above the keyboard.
-  // const dynamicPaddingBottom =
-  //   insets.bottom + (keyboardShown ? keyboardHeight : 0)
   return (
     <Screen title={messages.title} variant='white' url='/buy-sell'>
       <ScreenContent>
         <ScrollView
-          style={{ flex: 1 }}
+          style={{
+            flex: 1
+          }}
           contentContainerStyle={{
-            flexGrow: 1
+            flexGrow: 1,
+            // On Android, make sure the content can clear the foot when the keyboard is shown
+            // (On iOS, KeyboardAvoidingView handles this)
+            paddingBottom: Platform.OS === 'android' ? FIXED_FOOTER_HEIGHT : 0
           }}
           keyboardShouldPersistTaps='handled'
           showsVerticalScrollIndicator={false}
@@ -63,14 +63,30 @@ export const BuySellScreen = ({ route }: BuySellScreenProps) => {
             keyboardShowingOffset={insets.bottom}
           >
             <PoweredByJupiter />
-            <Flex mt='xl' p='l'>
+            <Flex mt='xl' p='l' style={{ flex: 1 }}>
               {flowData.content}
             </Flex>
           </KeyboardAvoidingView>
         </ScrollView>
-        <FixedFooter>{flowData.footer}</FixedFooter>
+        {/* Render footer outside scrollview so it doesn't move around when we adjust padding */}
+        <Paper
+          p='l'
+          justifyContent='center'
+          gap='s'
+          alignItems='center'
+          direction='column'
+          shadow='midInverted'
+          style={css({
+            position: 'absolute',
+            bottom: 0,
+            width: '100%',
+            borderRadius: 0,
+            paddingBottom: insets.bottom === 0 ? spacing.l : insets.bottom
+          })}
+        >
+          {flowData.footer}
+        </Paper>
       </ScreenContent>
-      {/* <FixedFooter avoidKeyboard>{flowData.footer}</FixedFooter> */}
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/wallet-screen/components/YourCoins.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/YourCoins.tsx
@@ -118,7 +118,7 @@ export const YourCoins = () => {
         {isLoadingCoins || !currentUserId ? (
           <YourCoinsSkeleton />
         ) : (
-          cards.map((item) => (
+          cards.map((item, idx) => (
             <Box key={typeof item === 'string' ? item : item.mint}>
               {item === 'discover-artist-coins' ? (
                 <DiscoverArtistCoinsCard onPress={handleDiscoverArtistCoins} />
@@ -127,7 +127,7 @@ export const YourCoins = () => {
               ) : (
                 <CoinCard mint={item.mint} />
               )}
-              <Divider />
+              {idx !== cards.length - 1 && <Divider />}
             </Box>
           ))
         )}


### PR DESCRIPTION
### Description
It's not a full fix, but it makes this slightly better. I can follow up with a more ambitious plan to track the currently focused input and make sure it stays in view when the keyboard is shown.

* Remove usage of `FixedFooter` in favor of a less-nested element that stays hidden behind keyboard on iOS (but still pinned to bottom) and is correctly positioned above keyboard on Android (there was a gap below the element when rendered there)
* Uses our `KeyboardAvodingView` instead of manually adding padding based on keyboard visibility. I updated that view to support the 'padding' mode where it adjusts bottom padding instead of translating the content. The reason I want to use `KeyboardAvoidingView` is that it sets the new padding before showing/hiding instead of us doing a render afterwards that feels janky
  * Note: For Android, since KAV doesn't do anything (because we don't watch the right events there), I chose to add a fixed padding amount to the bottom of the scrollview content. This will ensure that you can scroll the view far enough to see everything if the footer makes its way above the content due to the keyboard showing.
* Fixed a bug where switching tabs while focused would not blur the input, causing keyboard to stay visible. This due to our usage of `keyboardShouldPersistTaps='handled'` (good idea for most of this view, but the segment controls do handle the press, so keyboard will stay unless we manually dismiss it)
* Tiny bonus fix for PE-7096 to remove an extra divider in the coins section

### How Has This Been Tested?
local prod build on physical iOS and android devices. Did a lot of focusing and blurring in the various tabs of the buy/sell flow.
