### PR TITLE
[PE-7126] Wait for exchange rate before continuing

### DIFF
--- a/packages/common/src/store/ui/buy-sell/types.ts
+++ b/packages/common/src/store/ui/buy-sell/types.ts
@@ -79,6 +79,7 @@ export type TransactionData = {
   isValid: boolean
   error?: string | null
   exchangeRate?: number | null
+  isExchangeRateLoading?: boolean
 } | null
 
 /**

--- a/packages/common/src/store/ui/buy-sell/useTokenSwapForm.ts
+++ b/packages/common/src/store/ui/buy-sell/useTokenSwapForm.ts
@@ -245,7 +245,8 @@ export const useTokenSwapForm = ({
       isValid: swapValidation.isValid,
       error,
       isInsufficientBalance,
-      exchangeRate: currentExchangeRate
+      exchangeRate: currentExchangeRate,
+      isExchangeRateLoading
     }),
     [
       numericInputAmount,
@@ -253,7 +254,8 @@ export const useTokenSwapForm = ({
       swapValidation.isValid,
       error,
       isInsufficientBalance,
-      currentExchangeRate
+      currentExchangeRate,
+      isExchangeRateLoading
     ]
   )
 

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx
@@ -227,7 +227,11 @@ export const BuySellFlow = ({
 
   const handleContinueClick = useCallback(() => {
     setHasAttemptedSubmit(true)
-    if (transactionData?.isValid && !isContinueButtonLoading) {
+    if (
+      transactionData?.isValid &&
+      !isContinueButtonLoading &&
+      !transactionData?.isExchangeRateLoading
+    ) {
       trackSwapRequested({
         activeTab,
         inputToken: swapTokens.inputToken,
@@ -253,6 +257,7 @@ export const BuySellFlow = ({
     transactionData?.isValid,
     transactionData?.inputAmount,
     transactionData?.outputAmount,
+    transactionData?.isExchangeRateLoading,
     isContinueButtonLoading,
     trackSwapRequested,
     activeTab,
@@ -405,7 +410,10 @@ export const BuySellFlow = ({
       <Button
         variant='primary'
         fullWidth
-        isLoading={isContinueButtonLoading}
+        isLoading={
+          isContinueButtonLoading || transactionData?.isExchangeRateLoading
+        }
+        disabled={transactionData?.isExchangeRateLoading}
         onPress={handleContinueClick}
       >
         {messages.continue}

--- a/packages/web/src/components/buy-sell-modal/BuySellFlow.tsx
+++ b/packages/web/src/components/buy-sell-modal/BuySellFlow.tsx
@@ -328,7 +328,11 @@ export const BuySellFlow = (props: BuySellFlowProps) => {
 
   const handleContinueClick = () => {
     setHasAttemptedSubmit(true)
-    if (transactionData?.isValid && !isContinueButtonLoading) {
+    if (
+      transactionData?.isValid &&
+      !isContinueButtonLoading &&
+      !transactionData?.isExchangeRateLoading
+    ) {
       // Track swap requested
       trackSwapRequested({
         activeTab,
@@ -495,7 +499,10 @@ export const BuySellFlow = (props: BuySellFlowProps) => {
           <Button
             variant='primary'
             fullWidth
-            isLoading={isContinueButtonLoading}
+            isLoading={
+              isContinueButtonLoading || transactionData?.isExchangeRateLoading
+            }
+            disabled={transactionData?.isExchangeRateLoading}
             onClick={handleContinueClick}
           >
             {messages.continue}

--- a/packages/web/src/pages/artist-coins-launchpad-page/components/LaunchpadBuyModal.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/components/LaunchpadBuyModal.tsx
@@ -85,6 +85,7 @@ const FormInputStep = ({
   onContinue,
   availableBalance,
   isBalanceLoading,
+  isExchangeRateLoading,
   handleMaxClick: onMaxClick,
   onInputTokenChange,
   onInputAmountChange,
@@ -94,6 +95,7 @@ const FormInputStep = ({
   onContinue: () => void
   availableBalance: number
   isBalanceLoading: boolean
+  isExchangeRateLoading: boolean
   handleMaxClick: () => void
   onInputTokenChange: (token: TokenInfo) => void
   onInputAmountChange: (value: string) => void
@@ -237,7 +239,12 @@ const FormInputStep = ({
             />
           </Flex>
           {/* Button */}
-          <Button variant='primary' onClick={onContinue}>
+          <Button
+            variant='primary'
+            onClick={onContinue}
+            disabled={isExchangeRateLoading}
+            isLoading={isExchangeRateLoading}
+          >
             {buySellMessages.continue}
           </Button>
         </Flex>
@@ -442,6 +449,7 @@ export const LaunchpadBuyModal = ({
   const {
     availableBalance,
     isBalanceLoading,
+    isExchangeRateLoading,
     formik: buyModalForm,
     handleInputAmountChange,
     handleMaxClick,
@@ -460,7 +468,7 @@ export const LaunchpadBuyModal = ({
 
   const handleContinue = () => {
     track(make({ eventName: Name.LAUNCHPAD_BUY_MODAL_CONTINUE }))
-    if (currentStep === BuyModalStep.Form) {
+    if (currentStep === BuyModalStep.Form && !isExchangeRateLoading) {
       setCurrentStep(BuyModalStep.Confirmation)
     } else if (currentStep === BuyModalStep.Confirmation) {
       track(
@@ -514,6 +522,7 @@ export const LaunchpadBuyModal = ({
         onContinue={handleContinue}
         availableBalance={availableBalance}
         isBalanceLoading={isBalanceLoading}
+        isExchangeRateLoading={isExchangeRateLoading}
         handleMaxClick={handleMaxClick}
         onInputTokenChange={onInputTokenChange}
         onInputAmountChange={handleInputAmountChange}


### PR DESCRIPTION
### Description

Prevents user from continuing buy/sell/swap flow until exchange rate finishes loading