### PR TITLE
[PE-7026] Re-enable dismissing of toasts on Android

### DIFF
--- a/packages/mobile/src/components/toasts/Toast.tsx
+++ b/packages/mobile/src/components/toasts/Toast.tsx
@@ -4,7 +4,7 @@ import type { Toast as ToastType } from '@audius/common/store'
 import { toastActions } from '@audius/common/store'
 import { Link } from '@react-navigation/native'
 import type { To } from '@react-navigation/native/lib/typescript/src/useLinkTo'
-import { Animated, Platform, View } from 'react-native'
+import { Animated, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useDispatch } from 'react-redux'
 
@@ -73,9 +73,7 @@ export const Toast = (props: ToastProps) => {
   const handleDismiss = useCallback(() => {
     // Hack alert: For some reason, dismissing toasts on Android breaks the toast
     // system. It should be okay to let toasts persist on android for now.
-    if (Platform.OS === 'ios') {
-      dispatch(dismissToast({ key }))
-    }
+    dispatch(dismissToast({ key }))
   }, [dispatch, key])
 
   const animateOut = useCallback(() => {

--- a/packages/mobile/src/components/toasts/Toast.tsx
+++ b/packages/mobile/src/components/toasts/Toast.tsx
@@ -71,8 +71,6 @@ export const Toast = (props: ToastProps) => {
   const dispatch = useDispatch()
 
   const handleDismiss = useCallback(() => {
-    // Hack alert: For some reason, dismissing toasts on Android breaks the toast
-    // system. It should be okay to let toasts persist on android for now.
     dispatch(dismissToast({ key }))
   }, [dispatch, key])
 


### PR DESCRIPTION
### Description
This change: https://github.com/AudiusProject/apps/pull/10147
combined with this change: https://github.com/AudiusProject/audius-client/pull/3838
causes toasts to re-trigger when you load the BuySellModalScreen since we don't actually dismiss them on Android.

I was unable to reproduce the original issue that this was intended to fix (flag and hide a comment and toasts break on Android), so I'm proposing we remove this conditional.

If it feels too dangerous, I can try to rig up an alternate solution where we set some kind of `dismissed` flag on toasts and then don't show them on mount of a new Toast component.

### How Has This Been Tested?
Local prod build on Pixel 5 and Pixel 7, triggered various toasts and checked that they don't show when opening the `BuySellModalScreen`.
