### PR TITLE
Ellipsize ticker on mobile coin screen

### DIFF
--- a/packages/mobile/src/screens/coin-details-screen/components/BalanceCard.tsx
+++ b/packages/mobile/src/screens/coin-details-screen/components/BalanceCard.tsx
@@ -101,9 +101,14 @@ const HasBalanceState = ({
             <Text variant='heading' size='s'>
               {coinName || `$${ticker}`}
             </Text>
-            <Text variant='title' size='l'>
-              {tokenBalanceFormatted}
-            </Text>
+            <Flex row gap='xs' alignItems='center'>
+              <Text variant='title' size='l'>
+                {tokenBalanceFormatted}
+              </Text>
+              <Text variant='title' size='l' color='subdued'>
+                ${ticker}
+              </Text>
+            </Flex>
           </Flex>
         </Flex>
         <Flex row alignItems='center' gap='m' ml={spacing.unit22}>

--- a/packages/mobile/src/screens/coin-details-screen/components/BalanceCard.tsx
+++ b/packages/mobile/src/screens/coin-details-screen/components/BalanceCard.tsx
@@ -97,21 +97,29 @@ const HasBalanceState = ({
       <Flex row alignItems='center' justifyContent='space-between'>
         <Flex row alignItems='center' gap='l' style={{ flexShrink: 1 }}>
           <TokenIcon logoURI={logoURI} size={64} />
-          <Flex column gap='2xs'>
+          <Flex column gap='2xs' flex={1}>
             <Text variant='heading' size='s'>
               {coinName || `$${ticker}`}
             </Text>
-            <Flex row gap='xs' alignItems='center'>
+            <Flex row gap='xs' alignItems='center' flex={1}>
               <Text variant='title' size='l'>
                 {tokenBalanceFormatted}
               </Text>
-              <Text variant='title' size='l' color='subdued'>
+              <Text
+                variant='title'
+                size='l'
+                color='subdued'
+                numberOfLines={1}
+                style={{
+                  flexShrink: 1
+                }}
+              >
                 ${ticker}
               </Text>
             </Flex>
           </Flex>
         </Flex>
-        <Flex row alignItems='center' gap='m' ml={spacing.unit22}>
+        <Flex row alignItems='center' gap='m'>
           <Text
             variant='title'
             size='l'


### PR DESCRIPTION
### Description
Revert https://github.com/AudiusProject/apps/pull/13156 and ellipsize the ticker instead

### How Has This Been Tested?

hardcoded some vals
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-06 at 21 47 32" src="https://github.com/user-attachments/assets/0359bf2b-662d-4767-bc0d-125af98fe009" />
