### PR TITLE
[PE-7043] Add KeyboardAwareScrollView to buy/sell flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92767,6 +92767,15 @@
         "react-native": ">=0.42.0"
       }
     },
+    "node_modules/react-native-is-edge-to-edge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
+      "integrity": "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-keyboard-aware-scroll-view": {
       "version": "0.9.5",
       "license": "MIT",
@@ -92776,6 +92785,19 @@
       },
       "peerDependencies": {
         "react-native": ">=0.48.4"
+      }
+    },
+    "node_modules/react-native-keyboard-controller": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-controller/-/react-native-keyboard-controller-1.19.0.tgz",
+      "integrity": "sha512-G/SPwip7XWObjHLLpMB83pQoki8wQh0dPL4c+uEqxmaDUznnHvkiGuSTz0FWY0UUCeClw/iJ31DirMp6jBC2Jw==",
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-reanimated": ">=3.0.0"
       }
     },
     "node_modules/react-native-modal-selector": {
@@ -139193,6 +139215,7 @@
         "react-native-inset-shadow": "1.0.3",
         "react-native-intersection-observer": "0.2.1",
         "react-native-keyboard-aware-scroll-view": "0.9.5",
+        "react-native-keyboard-controller": "1.19.0",
         "react-native-linear-gradient": "2.8.3",
         "react-native-markdown-display": "7.0.2",
         "react-native-modal": "13.0.1",

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -1425,6 +1425,27 @@ PODS:
     - React-Core
   - react-native-keep-awake (1.2.2):
     - React-Core
+  - react-native-keyboard-controller (1.19.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.10.14.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - react-native-netinfo (11.2.1):
     - React-Core
   - react-native-notifications (5.1.0):
@@ -2159,6 +2180,7 @@ DEPENDENCIES:
   - react-native-image-picker (from `../../../node_modules/react-native-image-picker`)
   - react-native-in-app-review (from `../node_modules/react-native-in-app-review`)
   - "react-native-keep-awake (from `../node_modules/@sayem314/react-native-keep-awake`)"
+  - react-native-keyboard-controller (from `../../../node_modules/react-native-keyboard-controller`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-notifications (from `../node_modules/react-native-notifications`)
   - react-native-pager-view (from `../../../node_modules/react-native-pager-view`)
@@ -2351,6 +2373,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-in-app-review"
   react-native-keep-awake:
     :path: "../node_modules/@sayem314/react-native-keep-awake"
+  react-native-keyboard-controller:
+    :path: "../../../node_modules/react-native-keyboard-controller"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-notifications:
@@ -2538,6 +2562,7 @@ SPEC CHECKSUMS:
   react-native-image-picker: a05e7cf2b13aa348e6a5e2354bcf8b5033a8aed0
   react-native-in-app-review: db8bb167a5f238e7ceca5c242d6b36ce8c4404a4
   react-native-keep-awake: ad1d67f617756b139536977a0bf06b27cec0714a
+  react-native-keyboard-controller: b1ef38ac5c37c90479c1b5dc23bb095803dea20f
   react-native-netinfo: 8a7fd3f7130ef4ad2fb4276d5c9f8d3f28d2df3d
   react-native-notifications: 4601a5a8db4ced6ae7cfc43b44d35fe437ac50c4
   react-native-pager-view: ad90e78510ae4cb5f91d8b0d7ebb8a794c2ad266

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -135,6 +135,7 @@
     "react-native-inset-shadow": "1.0.3",
     "react-native-intersection-observer": "0.2.1",
     "react-native-keyboard-aware-scroll-view": "0.9.5",
+    "react-native-keyboard-controller": "1.19.0",
     "react-native-linear-gradient": "2.8.3",
     "react-native-markdown-display": "7.0.2",
     "react-native-modal": "13.0.1",

--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/react-native'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { Platform, UIManager } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
+import { KeyboardProvider } from 'react-native-keyboard-controller'
 import {
   SafeAreaProvider,
   initialWindowMetrics
@@ -61,42 +62,48 @@ const App = () => {
   return (
     <AppContextProvider>
       <SafeAreaProvider initialMetrics={initialWindowMetrics}>
-        <Provider store={store}>
-          <AudiusQueryProvider>
-            <QueryClientProvider client={queryClient}>
-              <SyncLocalStorageUserProvider localStorage={localStorage}>
-                <PersistGate loading={null} persistor={persistor}>
-                  <ThemeProvider>
-                    <GestureHandlerRootView style={{ flex: 1 }}>
-                      <PortalProvider>
-                        <ErrorBoundary>
-                          <ConnectivityManager />
-                          <NavigationContainer
-                            navigationIntegration={navigationIntegration}
-                          >
-                            <BottomSheetModalProvider>
-                              <CommentDrawerProvider>
-                                <Toasts />
-                                <Airplay />
-                                <RootScreen />
-                                <Drawers />
-                                <OAuthWebView />
-                                <NotificationReminder />
-                                <RateCtaReminder />
-                                <PortalHost name='ChatReactionsPortal' />
-                              </CommentDrawerProvider>
-                            </BottomSheetModalProvider>
-                            <PortalHost name='DrawerPortal' />
-                          </NavigationContainer>
-                        </ErrorBoundary>
-                      </PortalProvider>
-                    </GestureHandlerRootView>
-                  </ThemeProvider>
-                </PersistGate>
-              </SyncLocalStorageUserProvider>
-            </QueryClientProvider>
-          </AudiusQueryProvider>
-        </Provider>
+        <KeyboardProvider
+          statusBarTranslucent={true}
+          navigationBarTranslucent={true}
+          preserveEdgeToEdge={true}
+        >
+          <Provider store={store}>
+            <AudiusQueryProvider>
+              <QueryClientProvider client={queryClient}>
+                <SyncLocalStorageUserProvider localStorage={localStorage}>
+                  <PersistGate loading={null} persistor={persistor}>
+                    <ThemeProvider>
+                      <GestureHandlerRootView style={{ flex: 1 }}>
+                        <PortalProvider>
+                          <ErrorBoundary>
+                            <ConnectivityManager />
+                            <NavigationContainer
+                              navigationIntegration={navigationIntegration}
+                            >
+                              <BottomSheetModalProvider>
+                                <CommentDrawerProvider>
+                                  <Toasts />
+                                  <Airplay />
+                                  <RootScreen />
+                                  <Drawers />
+                                  <OAuthWebView />
+                                  <NotificationReminder />
+                                  <RateCtaReminder />
+                                  <PortalHost name='ChatReactionsPortal' />
+                                </CommentDrawerProvider>
+                              </BottomSheetModalProvider>
+                              <PortalHost name='DrawerPortal' />
+                            </NavigationContainer>
+                          </ErrorBoundary>
+                        </PortalProvider>
+                      </GestureHandlerRootView>
+                    </ThemeProvider>
+                  </PersistGate>
+                </SyncLocalStorageUserProvider>
+              </QueryClientProvider>
+            </AudiusQueryProvider>
+          </Provider>
+        </KeyboardProvider>
       </SafeAreaProvider>
     </AppContextProvider>
   )

--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -65,7 +65,6 @@ const App = () => {
         <KeyboardProvider
           statusBarTranslucent={true}
           navigationBarTranslucent={true}
-          preserveEdgeToEdge={true}
         >
           <Provider store={store}>
             <AudiusQueryProvider>

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellScreen.tsx
@@ -2,17 +2,11 @@ import React from 'react'
 
 import { buySellMessages as messages } from '@audius/common/messages'
 import { css } from '@emotion/native'
-import { Platform } from 'react-native'
+import { KeyboardAwareScrollView } from 'react-native-keyboard-controller'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import { Flex, Paper, spacing } from '@audius/harmony-native'
-import {
-  Screen,
-  ScreenContent,
-  ScrollView,
-  KeyboardAvoidingView
-} from 'app/components/core'
-import { FIXED_FOOTER_HEIGHT } from 'app/components/core/FixedFooter'
+import { Screen, ScreenContent } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
 
 import type { BuySellScreenParams } from '../../types/navigation'
@@ -44,30 +38,16 @@ export const BuySellScreen = ({ route }: BuySellScreenProps) => {
   return (
     <Screen title={messages.title} variant='white' url='/buy-sell'>
       <ScreenContent>
-        <ScrollView
-          style={{
-            flex: 1
-          }}
-          contentContainerStyle={{
-            flexGrow: 1,
-            // On Android, make sure the content can clear the foot when the keyboard is shown
-            // (On iOS, KeyboardAvoidingView handles this)
-            paddingBottom: Platform.OS === 'android' ? FIXED_FOOTER_HEIGHT : 0
-          }}
+        <KeyboardAwareScrollView
+          bottomOffset={spacing['2xl']}
           keyboardShouldPersistTaps='handled'
           showsVerticalScrollIndicator={false}
         >
-          <KeyboardAvoidingView
-            style={{ flex: 1 }}
-            behavior='padding'
-            keyboardShowingOffset={insets.bottom}
-          >
-            <PoweredByJupiter />
-            <Flex mt='xl' p='l' style={{ flex: 1 }}>
-              {flowData.content}
-            </Flex>
-          </KeyboardAvoidingView>
-        </ScrollView>
+          <PoweredByJupiter />
+          <Flex mt='xl' p='l' style={{ flex: 1 }}>
+            {flowData.content}
+          </Flex>
+        </KeyboardAwareScrollView>
         {/* Render footer outside scrollview so it doesn't move around when we adjust padding */}
         <Paper
           p='l'


### PR DESCRIPTION
### Description
This leverages [react-native-keyboard-controller](https://kirillzyusko.github.io/react-native-keyboard-controller/) to control scroll position on the ScrollView in the buy/sell flow. I've tested it out on physical iOS and Android devices and it seems pretty dang smooth. Generally could be a good replacement for all of our 'keyboard avoiding' type components. But we can do that one-by-one to reduce risk.

### How Has This Been Tested?
Staging apps on iOS and Android hardware devices. Went through the buy/sell screens, including convert, and made sure the focused input was moved above the keyboard when it is shown.
