### PR TITLE
Artist coin chat blast fixes

### DIFF
--- a/packages/common/src/hooks/chats/useFirstAvailableBlastAudience.ts
+++ b/packages/common/src/hooks/chats/useFirstAvailableBlastAudience.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { ChatBlastAudience } from '@audius/sdk'
 
 import {
+  useArtistCoinMembersCount,
   useCurrentAccountUser,
   usePurchasersCount,
   useRemixersCount
@@ -13,18 +14,21 @@ export const useFirstAvailableBlastAudience = () => {
 
   const { data: purchasersCount } = usePurchasersCount()
   const { data: remixersCount } = useRemixersCount()
+  const { data: membersCount } = useArtistCoinMembersCount()
 
   const firstAvailableAudience = useMemo(() => {
     if (user?.follower_count) return ChatBlastAudience.FOLLOWERS
     if (user?.supporter_count) return ChatBlastAudience.TIPPERS
     if (purchasersCount) return ChatBlastAudience.CUSTOMERS
     if (remixersCount) return ChatBlastAudience.REMIXERS
+    if (membersCount) return ChatBlastAudience.COIN_HOLDERS
     return null
   }, [
     user?.follower_count,
     user?.supporter_count,
     purchasersCount,
-    remixersCount
+    remixersCount,
+    membersCount
   ])
 
   return firstAvailableAudience

--- a/packages/common/src/hooks/useArtistCoinMessageHeader.ts
+++ b/packages/common/src/hooks/useArtistCoinMessageHeader.ts
@@ -30,7 +30,7 @@ export const useArtistCoinMessageHeader = ({
 
   let ticker
   if (coin) {
-    ticker = `$${coin.ticker}`
+    ticker = `${coin.ticker}`
   }
 
   return ticker

--- a/packages/mobile/src/screens/chat-screen/ArtistCoinHeader.tsx
+++ b/packages/mobile/src/screens/chat-screen/ArtistCoinHeader.tsx
@@ -2,9 +2,10 @@ import { useTokens } from '@audius/common/api'
 import { useArtistCoinMessageHeader } from '@audius/common/hooks'
 import type { ID } from '@audius/common/models'
 import type { ChatBlastAudience } from '@audius/sdk'
-import { Image, Platform } from 'react-native'
+import { Platform } from 'react-native'
 
-import { Flex, HexagonalIcon, spacing, Text } from '@audius/harmony-native'
+import { Flex, Text } from '@audius/harmony-native'
+import { TokenIcon } from 'app/components/core/TokenIcon'
 
 const messages = {
   membersOnly: 'Members Only'
@@ -21,7 +22,7 @@ export const ArtistCoinHeader = ({
     userId,
     audience
   })
-  const { tokens, isLoading } = useTokens()
+  const { tokens } = useTokens()
 
   if (!artistCoinSymbol) return null
 
@@ -37,17 +38,7 @@ export const ArtistCoinHeader = ({
       borderBottom='default'
     >
       <Flex row gap='xs' alignItems='center'>
-        {!isLoading ? (
-          <HexagonalIcon size={spacing.m}>
-            <Image
-              source={{ uri: tokens[artistCoinSymbol]?.logoURI }}
-              style={{
-                width: spacing.m,
-                height: spacing.m
-              }}
-            />
-          </HexagonalIcon>
-        ) : undefined}
+        <TokenIcon logoURI={tokens[artistCoinSymbol]?.logoURI} size='xs' />
         {/* Alignment bug for label text variant on iOS */}
         <Flex mt={Platform.OS === 'ios' ? '2xs' : 'none'}>
           <Text variant='label' size='s'>

--- a/packages/web/src/components/buy-sell-modal/TokenIcon.tsx
+++ b/packages/web/src/components/buy-sell-modal/TokenIcon.tsx
@@ -27,6 +27,7 @@ export const TokenIcon = ({
   if (logoURI) {
     // Handle different size props for Artwork component
     const sizeMap: Record<string, { w: number; h: number }> = {
+      xs: { w: 14, h: 14 }, // Used for ChatBlastHeader, non-standard size
       s: { w: spacing.unit4, h: spacing.unit4 },
       m: { w: spacing.unit5, h: spacing.unit5 },
       l: { w: spacing.unit6, h: spacing.unit6 },

--- a/packages/web/src/pages/chat-page/components/ArtistCoinHeader.tsx
+++ b/packages/web/src/pages/chat-page/components/ArtistCoinHeader.tsx
@@ -1,8 +1,10 @@
 import { useTokens } from '@audius/common/api'
 import { useArtistCoinMessageHeader } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
-import { Artwork, Flex, spacing, Text } from '@audius/harmony'
+import { Flex, Text } from '@audius/harmony'
 import { ChatBlastAudience } from '@audius/sdk'
+
+import { TokenIcon } from 'components/buy-sell-modal/TokenIcon'
 
 const messages = {
   membersOnly: 'Members Only'
@@ -20,7 +22,7 @@ export const ArtistCoinHeader = ({
     audience
   })
 
-  const { tokens, isLoading } = useTokens()
+  const { tokens } = useTokens()
 
   if (!artistCoinSymbol) return null
 
@@ -35,15 +37,7 @@ export const ArtistCoinHeader = ({
       borderBottom='default'
     >
       <Flex gap='xs' alignItems='center'>
-        {!isLoading ? (
-          <Artwork
-            src={tokens[artistCoinSymbol]?.logoURI}
-            hex
-            w={spacing.m}
-            h={spacing.m}
-            borderWidth={0}
-          />
-        ) : undefined}
+        <TokenIcon logoURI={tokens[artistCoinSymbol]?.logoURI} size='xs' hex />
         <Text variant='label' size='s'>
           {artistCoinSymbol}
         </Text>


### PR DESCRIPTION
### Description
- If artist has no other possible audiences except coin audience, the continue button on the blast modal was disabled.
- The token icon in the artist coin header for blasts was stuck in loading state forever due to `$` bug.

### How Has This Been Tested?

<img width="1920" height="1080" alt="Screenshot 2025-10-07 at 3 42 10 PM" src="https://github.com/user-attachments/assets/f1189311-3255-479c-b0d0-a19c06cd0bb2" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-07 at 15 40 56" src="https://github.com/user-attachments/assets/bb4de396-ad01-4e1d-8ded-27a18791d289" />
