### PR TITLE
Don't use on-chain description as default in-app description

### DIFF
--- a/packages/web/src/hooks/useLaunchCoin.ts
+++ b/packages/web/src/hooks/useLaunchCoin.ts
@@ -172,8 +172,8 @@ export const useLaunchCoin = () => {
               ticker: `${symbolUpper}`,
               decimals: LAUNCHPAD_COIN_DECIMALS,
               name,
-              logoUri: imageUri,
-              description
+              logoUri: imageUri
+              // intentionally don't send description - default to null
             }
           })
           errorMetadata.sdkCoinAdded = true


### PR DESCRIPTION
Not for today - but a fast follow to prevent the weirdness with artist coins page having a link to itself