### PR TITLE
feat(sdk): sign audio uploads and send the uploading user id

### DIFF
--- a/.changeset/sdk-sign-audio-uploads.md
+++ b/.changeset/sdk-sign-audio-uploads.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': minor
+---
+
+Sign audio uploads with EIP-712 and send the uploading user's id. `uploadTrackFiles` now accepts `userId`, and `Storage` accepts an `audiusWalletClient`; when both are present, audio uploads carry typed-data signature identifying the wallet the bytes came from. Storage nodes use it to attest on chain who uploaded a file, which is what makes the resulting cids claimable on a track. Image uploads are unchanged — they are served unauthenticated, and signup uploads a profile picture before the account has a user id. Audio uploaded without a signature still succeeds but cannot later be claimed.

--- a/packages/common/src/api/tan-query/upload/useUpload.ts
+++ b/packages/common/src/api/tan-query/upload/useUpload.ts
@@ -1,6 +1,6 @@
 import { useRef, useCallback } from 'react'
 
-import { HashId, type UploadTrackFilesTask } from '@audius/sdk'
+import { HashId, Id, type UploadTrackFilesTask } from '@audius/sdk'
 import { useDispatch } from 'react-redux'
 
 import { fileToSdk } from '~/adapters'
@@ -15,6 +15,7 @@ import {
   UploadType
 } from '~/store'
 
+import { useCurrentAccount } from '../users/account/useCurrentAccount'
 import { type QueryContextType, useQueryContext } from '../utils'
 
 import { usePublishCollection } from './usePublishCollection'
@@ -31,7 +32,8 @@ const {
 
 const getStemUploadTasks = async (
   context: Pick<QueryContextType, 'audiusSdk' | 'dispatch'>,
-  tracks: TrackForUpload[]
+  tracks: TrackForUpload[],
+  userId: number | undefined
 ) => {
   const sdk = await context.audiusSdk()
   return tracks.flatMap(
@@ -40,6 +42,7 @@ const getStemUploadTasks = async (
         const file = (stemFile as StemUploadWithFile).file
         const task = sdk.tracks.uploadTrackFiles({
           audioFile: fileToSdk(file, 'audio'),
+          userId: userId === undefined ? undefined : Id.parse(userId),
           onProgress: (_, { key, loaded, total, transcode }) => {
             context.dispatch(
               updateProgress({
@@ -120,12 +123,14 @@ const getCoverArtUploadTasks = async (
 
 const getTrackUploadTasks = async (
   context: Pick<QueryContextType, 'audiusSdk' | 'dispatch'>,
-  tracks: TrackForUpload[]
+  tracks: TrackForUpload[],
+  userId: number | undefined
 ) => {
   const sdk = await context.audiusSdk()
   return tracks.map((t) => {
     const task = sdk.tracks.uploadTrackFiles({
       audioFile: fileToSdk(t.file, 'audio'),
+      userId: userId === undefined ? undefined : Id.parse(userId),
       onProgress: (_, { key, loaded, total, transcode }) => {
         context.dispatch(
           uploadActions.updateProgress({
@@ -162,6 +167,11 @@ export const useUpload = (
     audiusSdk,
     analytics: { make, track }
   } = useQueryContext()
+  // Audio uploads are signed for this user so the storage node can attest on
+  // chain who uploaded the bytes, which is what makes the resulting cids
+  // claimable on a track.
+  const { data: account } = useCurrentAccount()
+  const userId = account?.userId ?? undefined
 
   const { mutateAsync: publishTracksAsync } = usePublishTracks()
   const { mutateAsync: publishCollectionAsync } = usePublishCollection()
@@ -208,7 +218,11 @@ export const useUpload = (
         )
       })
 
-      const tasks = await getTrackUploadTasks({ audiusSdk, dispatch }, tracks)
+      const tasks = await getTrackUploadTasks(
+        { audiusSdk, dispatch },
+        tracks,
+        userId
+      )
 
       // Store the upload tasks for potential aborting later
       tasks.forEach((task, i) => {
@@ -324,7 +338,11 @@ export const useUpload = (
 
   const uploadStemFiles = useCallback(
     async (tracks: TrackForUpload[]) => {
-      const tasks = await getStemUploadTasks({ audiusSdk, dispatch }, tracks)
+      const tasks = await getStemUploadTasks(
+        { audiusSdk, dispatch },
+        tracks,
+        userId
+      )
       return await uploadFiles(tasks)
     },
     [audiusSdk, dispatch, uploadFiles]

--- a/packages/sdk/src/sdk/api/tracks/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/tracks/TracksApi.ts
@@ -178,7 +178,7 @@ export class TracksApi extends GeneratedTracksApi {
     let totalProgressPercentage = 0
     return {
       start: async () => {
-        const { audioFile, imageFile, fileMetadata, onProgress } =
+        const { audioFile, imageFile, fileMetadata, userId, onProgress } =
           await parseParams('uploadTrackFiles', UploadTrackFilesSchema)(params)
 
         imageUpload = imageFile
@@ -214,6 +214,7 @@ export class TracksApi extends GeneratedTracksApi {
                 template: 'audio',
                 filename: audioFile.name ?? undefined,
                 filetype: audioFile.type ?? undefined,
+                userId,
                 placementHosts: fileMetadata?.placementHosts,
                 previewStartSeconds: fileMetadata?.previewStartSeconds
               }
@@ -396,6 +397,7 @@ export class TracksApi extends GeneratedTracksApi {
       await this.uploadTrackFiles({
         audioFile: params.audioFile,
         imageFile: params.imageFile,
+        userId: params.userId,
         fileMetadata: {
           placementHosts: params.metadata.placementHosts,
           previewStartSeconds: params.metadata.previewStartSeconds
@@ -480,6 +482,7 @@ export class TracksApi extends GeneratedTracksApi {
       await this.uploadTrackFiles({
         audioFile: params.audioFile,
         imageFile: params.imageFile,
+        userId: params.userId,
         fileMetadata: {
           placementHosts: params.metadata.placementHosts,
           previewStartSeconds: params.metadata.previewStartSeconds

--- a/packages/sdk/src/sdk/api/tracks/types.ts
+++ b/packages/sdk/src/sdk/api/tracks/types.ts
@@ -273,6 +273,10 @@ export const UploadTrackFilesSchema = z
   .object({
     audioFile: z.optional(AudioFile),
     imageFile: z.optional(ImageFile),
+    // Audio uploads are signed for this user so the storage node can attest
+    // on chain who uploaded the bytes. Without it the upload still succeeds
+    // but never becomes claimable on a track.
+    userId: z.optional(HashId),
     fileMetadata: z
       .object({
         placementHosts: z.string().optional(),

--- a/packages/sdk/src/sdk/createSdkWithServices.ts
+++ b/packages/sdk/src/sdk/createSdkWithServices.ts
@@ -200,6 +200,7 @@ const initializeServices = ({
     new Storage({
       ...getDefaultStorageServiceConfig(servicesConfig),
       storageNodeSelector,
+      audiusWalletClient,
       logger
     })
 

--- a/packages/sdk/src/sdk/services/Storage/Storage.ts
+++ b/packages/sdk/src/sdk/services/Storage/Storage.ts
@@ -4,11 +4,14 @@ import { productionConfig } from '../../config/production'
 import fetch from '../../utils/fetch'
 import { mergeConfigWithDefaults } from '../../utils/mergeConfigs'
 import { wait } from '../../utils/wait'
+import type { AudiusWalletClient } from '../AudiusWalletClient'
 import type { LoggerService } from '../Logger'
 import type { StorageNodeSelectorService } from '../StorageNodeSelector'
 
 import { getDefaultStorageServiceConfig } from './getDefaultConfig'
+import { signUpload } from './signUpload'
 import type {
+  FileMetadata,
   FileTemplate,
   ProgressHandler,
   StorageService,
@@ -29,6 +32,7 @@ export class Storage implements StorageService {
    */
   private readonly config: StorageServiceConfigInternal
   private readonly storageNodeSelector: StorageNodeSelectorService
+  private readonly audiusWalletClient: AudiusWalletClient | undefined
   private readonly logger: LoggerService
 
   constructor(config: StorageServiceConfig) {
@@ -37,7 +41,59 @@ export class Storage implements StorageService {
       getDefaultStorageServiceConfig(productionConfig)
     )
     this.storageNodeSelector = config.storageNodeSelector
+    this.audiusWalletClient = config.audiusWalletClient
     this.logger = this.config.logger.createPrefixedLogger('[storage]')
+  }
+
+  /**
+   * Builds the tus metadata that identifies who an upload belongs to.
+   *
+   * Audio is signed so the storage node can attest on chain which wallet
+   * uploaded the bytes; that attestation is what lets the uploader name the
+   * resulting cids on a track. Images are left alone — they are served
+   * unauthenticated, so there is nothing to claim, and requiring a signature
+   * would break signup, which uploads a profile picture before the account
+   * has a user id.
+   *
+   * A missing wallet client or user id is not fatal. The upload proceeds
+   * unsigned and simply never earns an attestation, which fails later at the
+   * point of claiming rather than here.
+   */
+  private async getUploadAuthMetadata(
+    metadata: FileMetadata
+  ): Promise<Record<string, string>> {
+    if (metadata.template !== 'audio') {
+      return {}
+    }
+    if (!this.audiusWalletClient || metadata.userId === undefined) {
+      this.logger.warn(
+        'uploading audio without a signature; it will not be claimable on a track',
+        {
+          hasWallet: !!this.audiusWalletClient,
+          hasUserId: metadata.userId !== undefined
+        }
+      )
+      return {}
+    }
+
+    try {
+      const { signature, userId, timestamp } = await signUpload({
+        audiusWalletClient: this.audiusWalletClient,
+        userId: metadata.userId
+      })
+      // The signed fields travel alongside the signature because the verifier
+      // needs them to reconstruct the typed data. They are reproduced inside
+      // the signed payload, so tampering with either only breaks recovery — it
+      // cannot redirect the upload to another user.
+      return {
+        signature,
+        userId: userId.toString(),
+        timestamp: timestamp.toString()
+      }
+    } catch (e) {
+      this.logger.error('failed to sign upload', e)
+      throw e
+    }
   }
 
   /**
@@ -54,6 +110,10 @@ export class Storage implements StorageService {
         if (uploadPromise) {
           return uploadPromise
         }
+        // Sign before selecting a node so a signing failure surfaces as such,
+        // rather than as an opaque upload rejection later.
+        const authMetadata = await this.getUploadAuthMetadata(metadata)
+
         uploadPromise = new Promise<UploadResponse>((resolve, reject) => {
           this.storageNodeSelector
             .getSelectedNode()
@@ -85,6 +145,7 @@ export class Storage implements StorageService {
                     file.type ||
                     'application/octet-stream',
                   template: metadata.template,
+                  ...authMetadata,
                   ...(metadata.placementHosts
                     ? { placementHosts: metadata.placementHosts }
                     : {}),

--- a/packages/sdk/src/sdk/services/Storage/signUpload.test.ts
+++ b/packages/sdk/src/sdk/services/Storage/signUpload.test.ts
@@ -1,0 +1,113 @@
+import { recoverTypedDataAddress, type Hex } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { describe, expect, it } from 'vitest'
+
+import type { AudiusWalletClient } from '../AudiusWalletClient'
+
+import { signUpload } from './signUpload'
+
+const TEST_PRIVATE_KEY =
+  '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
+
+const account = privateKeyToAccount(TEST_PRIVATE_KEY)
+
+/**
+ * Minimal stand-in for the wallet client: signUpload only needs an address and
+ * signTypedData, and going through viem's real account keeps the signature
+ * genuinely verifiable rather than mocked.
+ */
+const walletClient = {
+  account,
+  getAddresses: async () => [account.address],
+  signTypedData: async (args: any) => account.signTypedData(args)
+} as unknown as AudiusWalletClient
+
+// Must stay in lockstep with pkg/core/server/upload_request_eip712.go.
+const DOMAIN = { name: 'Audius Upload', version: '1' } as const
+const TYPES = {
+  UploadRequest: [
+    { name: 'userId', type: 'uint256' },
+    { name: 'timestamp', type: 'uint256' }
+  ]
+} as const
+
+describe('signUpload', () => {
+  // Everything the verifier needs to rebuild the typed data comes back
+  // together; an EIP-712 signature does not carry its own message.
+  it('returns the signature and every field it covers', async () => {
+    const result = await signUpload({
+      audiusWalletClient: walletClient,
+      userId: 42,
+      timestamp: 1700000000000
+    })
+
+    expect(result.signature).toMatch(/^0x[0-9a-f]{130}$/i)
+    expect(result.userId).toBe(42)
+    expect(result.timestamp).toBe(1700000000000)
+  })
+
+  // The validator reconstructs the typed data from userId and timestamp and
+  // recovers against it. If the domain or types drift from the Go side, every
+  // upload fails auth — so pin the exact shape here.
+  it('signs the agreed typed data', async () => {
+    const { signature, timestamp } = await signUpload({
+      audiusWalletClient: walletClient,
+      userId: 7,
+      timestamp: 1700000000000
+    })
+
+    const recovered = await recoverTypedDataAddress({
+      domain: DOMAIN,
+      types: TYPES,
+      primaryType: 'UploadRequest',
+      message: { userId: BigInt(7), timestamp: BigInt(timestamp) },
+      signature: signature as Hex
+    })
+
+    expect(recovered.toLowerCase()).toBe(account.address.toLowerCase())
+  })
+
+  it('binds the signature to the user id', async () => {
+    const [a, b] = await Promise.all([
+      signUpload({
+        audiusWalletClient: walletClient,
+        userId: 1,
+        timestamp: 1700000000000
+      }),
+      signUpload({
+        audiusWalletClient: walletClient,
+        userId: 2,
+        timestamp: 1700000000000
+      })
+    ])
+
+    expect(a.signature).not.toBe(b.signature)
+  })
+
+  it('binds the signature to the timestamp', async () => {
+    const [a, b] = await Promise.all([
+      signUpload({
+        audiusWalletClient: walletClient,
+        userId: 1,
+        timestamp: 1700000000000
+      }),
+      signUpload({
+        audiusWalletClient: walletClient,
+        userId: 1,
+        timestamp: 1700000000001
+      })
+    ])
+
+    expect(a.signature).not.toBe(b.signature)
+  })
+
+  it('throws when no wallet address is available', async () => {
+    const empty = {
+      getAddresses: async () => []
+    } as unknown as AudiusWalletClient
+
+    await expect(
+      signUpload({ audiusWalletClient: empty, userId: 1 })
+    ).rejects.toThrow('No wallet available')
+  })
+})

--- a/packages/sdk/src/sdk/services/Storage/signUpload.ts
+++ b/packages/sdk/src/sdk/services/Storage/signUpload.ts
@@ -1,0 +1,95 @@
+import type { TypedData } from 'viem'
+
+import type { AudiusWalletClient } from '../AudiusWalletClient'
+
+/**
+ * EIP-712 typed data for the signature a client presents when starting an
+ * upload. It proves which wallet is asking to upload, before any content
+ * exists to name.
+ *
+ * Typed data rather than a hashed JSON payload for two reasons. It removes
+ * JSON canonicalization from the protocol entirely — the type definition is
+ * the encoding, so there is no key ordering or number formatting for client
+ * and server to agree on and later drift apart over. And it provides domain
+ * separation, which a bare hashed payload does not: without a domain, a
+ * signature produced for any other purpose over the same two fields would be
+ * replayable as an upload authorization.
+ *
+ * This mirrors how the SDK already signs entity-manager writes, so both sides
+ * use standard calls — `signTypedData` here, go-ethereum's `apitypes` on the
+ * validator — rather than a hand-rolled hashing scheme.
+ *
+ * The domain carries name and version only. `verifyingContract` is omitted
+ * because uploads are not a contract interaction, and `chainId` is omitted so
+ * storage nodes need no chain configuration to verify. Keep these in lockstep
+ * with pkg/core/server/upload_request_eip712.go — a mismatch in any field
+ * makes every signature fail to recover.
+ */
+const UPLOAD_REQUEST_DOMAIN = {
+  name: 'Audius Upload',
+  version: '1'
+} as const
+
+const UPLOAD_REQUEST_TYPES = {
+  UploadRequest: [
+    { name: 'userId', type: 'uint256' },
+    { name: 'timestamp', type: 'uint256' }
+  ]
+} as const satisfies TypedData
+
+/**
+ * A signature plus the message it commits to. Every field the verifier needs
+ * to rebuild the typed data is returned together, because an EIP-712 signature
+ * does not carry its own message — recovery needs the exact fields that were
+ * signed. Returning only some of them would leave the caller to re-derive the
+ * rest and risk them drifting from what was actually signed.
+ */
+export type UploadRequestSignature = {
+  /** Hex signature over the typed data. */
+  signature: string
+  /** User id covered by the signature. */
+  userId: number
+  /** Millisecond timestamp covered by the signature. */
+  timestamp: number
+}
+
+/**
+ * Signs an upload request for the given user.
+ *
+ * The payload deliberately does not name the content: at the time an upload is
+ * created the bytes have not been sent, so nobody — client or node — knows the
+ * cid yet. Binding to content happens on the other side, when the storage node
+ * attests to the cids it produced from the bytes this wallet sent, and that
+ * attestation is what entitles the wallet to claim them on a track.
+ *
+ * The timestamp is returned alongside the signature because the verifier needs
+ * it to reconstruct the typed data. It is reproduced inside the signed payload,
+ * so altering it in transit only breaks recovery.
+ */
+export const signUpload = async ({
+  audiusWalletClient,
+  userId,
+  timestamp = Date.now()
+}: {
+  audiusWalletClient: AudiusWalletClient
+  userId: number
+  timestamp?: number
+}): Promise<UploadRequestSignature> => {
+  const [account] = await audiusWalletClient.getAddresses()
+  if (!account) {
+    throw new Error('No wallet available to sign upload')
+  }
+
+  const signature = await audiusWalletClient.signTypedData({
+    account,
+    domain: UPLOAD_REQUEST_DOMAIN,
+    types: UPLOAD_REQUEST_TYPES,
+    primaryType: 'UploadRequest',
+    message: {
+      userId: BigInt(userId),
+      timestamp: BigInt(timestamp)
+    }
+  })
+
+  return { signature, userId, timestamp }
+}

--- a/packages/sdk/src/sdk/services/Storage/types.ts
+++ b/packages/sdk/src/sdk/services/Storage/types.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import type { CrossPlatformFile } from '../../types/File'
+import type { AudiusWalletClient } from '../AudiusWalletClient'
 import type { LoggerService } from '../Logger'
 import type { StorageNodeSelectorService } from '../StorageNodeSelector'
 
@@ -31,6 +32,12 @@ export type StorageServiceConfig = Partial<StorageServiceConfigInternal> & {
    * The StorageNodeSelector service used to get the relevant storage node for content
    */
   storageNodeSelector: StorageNodeSelectorService
+  /**
+   * Signs audio uploads so the storage node can attest on chain which wallet
+   * they came from. Optional: when absent, audio uploads go out unsigned and
+   * simply never earn an attestation, so they cannot later claim their cids.
+   */
+  audiusWalletClient?: AudiusWalletClient
 }
 
 export const ProgressEventSchema = z.object({
@@ -123,4 +130,13 @@ export type FileMetadata = {
   userWallet?: string
   previewStartSeconds?: number
   placementHosts?: string
+  /**
+   * Decoded user id the upload belongs to. Sent on every audio upload and
+   * carried inside the signature, so it cannot be swapped after signing.
+   *
+   * Image uploads leave this unset: signup uploads a profile picture before
+   * the account has a user id, and images are served unauthenticated anyway,
+   * so there is no claim to protect.
+   */
+  userId?: number
 }


### PR DESCRIPTION
Client half of a change to close a content-gating bypass. Server side is OpenAudio/go-openaudio#459 and OpenAudio/go-openaudio#460 — this can merge independently and is inert until those activate.

## Why

Storage nodes are moving to attesting on chain which wallet uploaded a file, because that attestation is what will entitle the uploader to name the resulting cids on a track. Today anyone can read a gated track's `track_cid` off the public API and assert it on their own ungated track, and nothing can tell the difference.

A node can only attest to an uploader it can identify, and right now it cannot: tus metadata carries no wallet, no user id and no signature, so `Upload.UserWallet` is read from an unsigned metadata key the SDK never sends and sits NULL on every SDK upload.

## What changes

`uploadTrackFiles` accepts `userId` and `Storage` accepts an `audiusWalletClient`. When both are present, audio uploads carry an EIP-712 signature over the user id and a timestamp, with both fields sent alongside so the validator can rebuild the typed data. They are reproduced inside the signed payload, so tampering with either in transit only breaks recovery — it cannot redirect the upload to another user.

## Why typed data rather than signed JSON

An earlier revision hashed canonical JSON and used `personal_sign`. EIP-712 is better on two counts:

- **No canonicalization.** The type definition is the encoding, so there is no key ordering or number formatting for client and server to agree on and later drift apart over.
- **Domain separation.** A bare hashed payload has none, so a signature produced for any other purpose over the same two fields would be replayable as an upload authorization.

It also matches how this SDK already signs entity-manager writes, so both sides use standard calls rather than a hand-rolled hashing scheme.

The payload deliberately does not name the content: at upload-create time the bytes have not been sent and nobody knows the cid yet. Binding to content happens on the node's side, once transcoding produces cids it can attest to.

## What is deliberately unchanged

**Image uploads.** They are served unauthenticated so there is no claim to protect, and requiring a signature would break signup, which uploads a profile picture before the account has a user id. The ordering nuance is that the Hedgehog wallet *does* exist by then — what does not is the user id, minted later inside `createUserWithEntityManager`. That is why the payload is keyed on the wallet.

**Unsigned uploads still succeed.** Without a wallet client or user id the upload proceeds and simply never earns an attestation, failing later at the point of claiming rather than blocking the upload.

## Testing

5 tests covering the returned shape, that the signature verifies against the agreed domain and types, binding to both the user id and the timestamp, and the no-wallet error.

There is a matching fixture test on the validator side pinning a real signature produced by this code, so the two independently-written implementations cannot drift apart silently. I confirmed a viem-signed payload recovers to the expected address in Go before wiring it up.

Both `packages/sdk` and `packages/common` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)