### PR TITLE
feat(sdk): sign preview generation requests

### DIFF
--- a/.changeset/sdk-sign-preview-generation.md
+++ b/.changeset/sdk-sign-preview-generation.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': minor
+---
+
+Sign preview generation requests. `Storage.generatePreview` accepts a `userId` and, when a wallet client is configured, signs the request with the same EIP-712 payload audio uploads use. Storage nodes attest the resulting cid on chain so it can be named as a track's `preview_cid`, and they only do so for a user who already owns the source audio. Requests without a wallet or user id still succeed unsigned; the preview simply never earns a claim.

--- a/packages/sdk/src/sdk/api/tracks/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/tracks/TracksApi.ts
@@ -269,7 +269,8 @@ export class TracksApi extends GeneratedTracksApi {
         async () =>
           await this.storage.generatePreview({
             cid: populatedMetadata.trackCid!,
-            secondOffset: populatedMetadata.previewStartSeconds!
+            secondOffset: populatedMetadata.previewStartSeconds!,
+            userId: decodeHashId(params.userId) ?? undefined
           }),
         (e) => {
           this.logger.info('Retrying generatePreview', e)
@@ -512,7 +513,8 @@ export class TracksApi extends GeneratedTracksApi {
         async () =>
           await this.storage.generatePreview({
             cid: metadata.trackCid!,
-            secondOffset: metadata.previewStartSeconds!
+            secondOffset: metadata.previewStartSeconds!,
+            userId: decodeHashId(params.userId) ?? undefined
           }),
         (e) => {
           this.logger.info('Retrying generatePreview', e)

--- a/packages/sdk/src/sdk/services/Storage/Storage.ts
+++ b/packages/sdk/src/sdk/services/Storage/Storage.ts
@@ -220,17 +220,27 @@ export class Storage implements StorageService {
 
   /**
    * Generates a preview for a track at the given second offset
+   *
+   * Signed for the same reason audio uploads are: the node attests the
+   * resulting cid on chain so it can be named as a track's preview, and it
+   * will only do that for a user who already owns the source audio. Previews
+   * stream publicly, so a preview cid anyone could claim would let an attacker
+   * slice a gated track into 30-second windows and reassemble it.
+   *
    * @param {Object} params
    * @param {string} params.cid - The CID of the track to generate a preview for
    * @param {number} params.secondOffset - The offset in seconds to start the preview from
+   * @param {number} params.userId - Decoded id of the user the source audio belongs to
    * @returns {Promise<string>} The CID of the generated preview
    */
   async generatePreview({
     cid,
-    secondOffset
+    secondOffset,
+    userId
   }: {
     cid: string
     secondOffset: number
+    userId?: number
   }) {
     const contentNodeEndpoint = await this.storageNodeSelector.getSelectedNode()
 
@@ -238,12 +248,24 @@ export class Storage implements StorageService {
       throw new Error('No content node available')
     }
 
-    const response = await fetch(
-      `${contentNodeEndpoint}/generate_preview/${cid}/${secondOffset}`,
-      {
-        method: 'POST'
-      }
+    const url = new URL(
+      `${contentNodeEndpoint}/generate_preview/${cid}/${secondOffset}`
     )
+
+    // Unsigned when there is no wallet or no user to sign for. The node
+    // accepts those where content authorization is not yet enforced, and the
+    // preview simply never earns a claim.
+    if (this.audiusWalletClient && userId !== undefined) {
+      const signed = await signUpload({
+        audiusWalletClient: this.audiusWalletClient,
+        userId
+      })
+      url.searchParams.set('signature', signed.signature)
+      url.searchParams.set('userId', String(signed.userId))
+      url.searchParams.set('timestamp', String(signed.timestamp))
+    }
+
+    const response = await fetch(url, { method: 'POST' })
     if (!response.ok) {
       throw new Error(
         `Failed to generate preview for cid ${cid} at offset ${secondOffset}, status: ${response.status}`

--- a/packages/sdk/src/sdk/services/Storage/types.ts
+++ b/packages/sdk/src/sdk/services/Storage/types.ts
@@ -86,10 +86,12 @@ export type StorageService = {
   getUploadStatus: (uploadId: string) => Promise<UploadResponse>
   generatePreview: ({
     cid,
-    secondOffset
+    secondOffset,
+    userId
   }: {
     cid: string
     secondOffset: number
+    userId?: number
   }) => Promise<string>
 }
 


### PR DESCRIPTION
Stacked on #14550. Review that first — this branch contains only the commit on top of it.

## Why previews need signing

`generatePreview` asks a storage node to slice new bytes out of a cid. The node attests the resulting cid on chain so it can be named as a track's `preview_cid` — and it will only do that for a user who already claims the source audio. So the request has to say who is asking.

Without that check the endpoint is a gating bypass. Previews stream publicly, and they are 30 seconds long, so an attacker could generate previews of a gated track at offsets 0/30/60/…, name each on a throwaway track of their own, and reassemble the full 320. Requiring a signature and refusing unless the caller owns the source kills that at the door.

## What changed

`generatePreview` takes an optional `userId` and, when a wallet is configured, signs with `signUpload` from #14550 — the same EIP-712 payload audio uploads use, passed as `signature`/`userId`/`timestamp` query parameters. Reusing it rather than inventing a second scheme means both audio paths recover a signer through one code path on the node side too.

Both call sites in `TracksApi` pass the acting user: the `uploadTrack` fallback that generates a preview when the upload did not, and `updateTrack` with `generatePreview: true`. The second is the one that matters most — it has no audio upload at all, so this endpoint is its only route to a preview cid.

## Unsigned still works

No wallet or no user id sends the request unsigned, matching `uploadFile`. Nodes accept those where content authorization is not enforced; the preview just never earns a claim, so it cannot be named on a track once enforcement is on. That makes this safe to land ahead of the gate but means it has to ship before the gate opens.

## Testing

Typechecks clean. The SDK's vitest suites do not run in my environment — `StorageNodeSelector.test.ts` and `signUpload.test.ts` both fail at collection with `TypeError: Object.defineProperty called on non-object`, and they fail identically on a clean tree with none of these changes, so it is environmental rather than caused by this branch. **These changes have not been exercised by a running test.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
