### PR TITLE
fix(sdk): close remaining unsigned audio upload paths from review

### DIFF
--- a/.changeset/sdk-sign-uploads-api-audio.md
+++ b/.changeset/sdk-sign-uploads-api-audio.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': minor
+---
+
+`uploads.createAudioUpload` accepts an optional encoded `userId`, and the default SDK factory wires the configured wallet client into its storage service, so audio uploaded through the uploads API is signed like track uploads are. Without a userId or wallet client the upload still succeeds unsigned and never earns an attestation.

--- a/packages/common/src/api/tan-query/upload/useUpload.ts
+++ b/packages/common/src/api/tan-query/upload/useUpload.ts
@@ -231,7 +231,7 @@ export const useUpload = (
 
       return await uploadFiles(tasks)
     },
-    [audiusSdk, dispatch, uploadFiles, track, make]
+    [audiusSdk, dispatch, uploadFiles, track, make, userId]
   )
 
   /**
@@ -345,7 +345,7 @@ export const useUpload = (
       )
       return await uploadFiles(tasks)
     },
-    [audiusSdk, dispatch, uploadFiles]
+    [audiusSdk, dispatch, uploadFiles, userId]
   )
 
   const startUpload = useCallback(

--- a/packages/mobile/examples/upload/App.tsx
+++ b/packages/mobile/examples/upload/App.tsx
@@ -182,7 +182,8 @@ export default function App() {
           uri: audioFile.uri,
           name: audioFile.name ?? 'audio',
           type: audioFile.mimeType ?? 'audio/mpeg'
-        }
+        },
+        userId: String(profile.id ?? '') || undefined
       })
 
       const imageUpload = coverUri

--- a/packages/sdk/src/sdk/api/tracks/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/tracks/TracksApi.ts
@@ -270,7 +270,7 @@ export class TracksApi extends GeneratedTracksApi {
           await this.storage.generatePreview({
             cid: populatedMetadata.trackCid!,
             secondOffset: populatedMetadata.previewStartSeconds!,
-            userId: decodeHashId(params.userId) ?? undefined
+            userId
           }),
         (e) => {
           this.logger.info('Retrying generatePreview', e)

--- a/packages/sdk/src/sdk/api/uploads/UploadsApi.ts
+++ b/packages/sdk/src/sdk/api/uploads/UploadsApi.ts
@@ -1,5 +1,6 @@
 import { type ProgressHandler } from '../../services'
 import type { CrossPlatformFile } from '../../types/File'
+import { decodeHashId } from '../../utils/hashId'
 
 import type { UploadsApiServicesConfig } from './types'
 
@@ -14,17 +15,25 @@ export class UploadsApi {
    * Creates an audio file upload task that uploads to a validator and returns
    * the resulting CIDs and analysis metadata.
    *
-   * Optionally accepts a callback for tracking upload progress, a list of
-   * placement hosts to prefer for storage, and a start time in seconds
-   * for generating a preview clip.
+   * Optionally accepts the uploading user's id, a callback for tracking
+   * upload progress, a list of placement hosts to prefer for storage, and a
+   * start time in seconds for generating a preview clip.
+   *
+   * When a userId is provided and the SDK is configured with a wallet client,
+   * the upload is signed so the validator can attest on chain who uploaded
+   * the bytes — which is what makes the resulting cids claimable on a track.
+   * Without it the upload still succeeds but never earns an attestation.
    */
   public createAudioUpload({
     file,
+    userId,
     onProgress,
     previewStartSeconds,
     placementHosts
   }: {
     file: CrossPlatformFile
+    /** The encoded id of the user uploading the audio */
+    userId?: string
     onProgress?: ProgressHandler
     placementHosts?: string[]
     previewStartSeconds?: number
@@ -36,6 +45,10 @@ export class UploadsApi {
         template: 'audio',
         filename: file.name ?? undefined,
         filetype: file.type ?? undefined,
+        userId:
+          userId === undefined
+            ? undefined
+            : (decodeHashId(userId) ?? undefined),
         previewStartSeconds,
         placementHosts: placementHosts?.join(',')
       }

--- a/packages/sdk/src/sdk/createSdk.ts
+++ b/packages/sdk/src/sdk/createSdk.ts
@@ -178,6 +178,7 @@ export const createSdk = (config: SdkConfig) => {
               endpoint: apiEndpoint, // health_check is at root, not /v1
               logger
             }),
+          audiusWalletClient: services?.audiusWalletClient,
           logger
         })
     })

--- a/packages/sdk/src/sdk/services/Storage/Storage.test.ts
+++ b/packages/sdk/src/sdk/services/Storage/Storage.test.ts
@@ -1,0 +1,119 @@
+import { recoverTypedDataAddress, type Hex } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import fetch from '../../utils/fetch'
+import type { AudiusWalletClient } from '../AudiusWalletClient'
+import type { StorageNodeSelectorService } from '../StorageNodeSelector'
+
+import { Storage } from './Storage'
+
+vi.mock('../../utils/fetch')
+
+const mockFetch = vi.mocked(fetch)
+
+const TEST_PRIVATE_KEY =
+  '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
+
+const account = privateKeyToAccount(TEST_PRIVATE_KEY)
+
+/**
+ * Minimal stand-in for the wallet client, matching signUpload.test.ts: going
+ * through viem's real account keeps the signature genuinely verifiable.
+ */
+const walletClient = {
+  account,
+  getAddresses: async () => [account.address],
+  signTypedData: async (args: any) => account.signTypedData(args)
+} as unknown as AudiusWalletClient
+
+const storageNodeSelector = {
+  getSelectedNode: async () => 'https://node.example.com'
+} as unknown as StorageNodeSelectorService
+
+// Must stay in lockstep with pkg/core/server/upload_request_eip712.go.
+const DOMAIN = { name: 'Audius Upload', version: '1' } as const
+const TYPES = {
+  UploadRequest: [
+    { name: 'userId', type: 'uint256' },
+    { name: 'timestamp', type: 'uint256' }
+  ]
+} as const
+
+const previewResponse = (cid: string) =>
+  ({ ok: true, json: async () => ({ cid }) }) as unknown as Response
+
+describe('generatePreview', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it('signs the request when a wallet and user id are present', async () => {
+    mockFetch.mockResolvedValue(previewResponse('preview-cid'))
+    const storage = new Storage({
+      storageNodeSelector,
+      audiusWalletClient: walletClient
+    })
+
+    const result = await storage.generatePreview({
+      cid: 'some-cid',
+      secondOffset: 30,
+      userId: 42
+    })
+
+    expect(result).toBe('preview-cid')
+    const [url, init] = mockFetch.mock.calls[0]! as [URL, RequestInit]
+    expect(init.method).toBe('POST')
+    expect(url.pathname).toBe('/generate_preview/some-cid/30')
+
+    // The query params carry everything the node needs to rebuild the typed
+    // data and recover the signer.
+    expect(url.searchParams.get('userId')).toBe('42')
+    const timestamp = url.searchParams.get('timestamp')
+    expect(timestamp).toMatch(/^\d+$/)
+    const recovered = await recoverTypedDataAddress({
+      domain: DOMAIN,
+      types: TYPES,
+      primaryType: 'UploadRequest',
+      message: { userId: BigInt(42), timestamp: BigInt(timestamp!) },
+      signature: url.searchParams.get('signature') as Hex
+    })
+    expect(recovered.toLowerCase()).toBe(account.address.toLowerCase())
+  })
+
+  it('sends the request unsigned when there is no user id', async () => {
+    mockFetch.mockResolvedValue(previewResponse('preview-cid'))
+    const storage = new Storage({
+      storageNodeSelector,
+      audiusWalletClient: walletClient
+    })
+
+    await storage.generatePreview({ cid: 'some-cid', secondOffset: 0 })
+
+    const [url] = mockFetch.mock.calls[0]! as [URL]
+    expect(url.search).toBe('')
+  })
+
+  it('sends the request unsigned when there is no wallet client', async () => {
+    mockFetch.mockResolvedValue(previewResponse('preview-cid'))
+    const storage = new Storage({ storageNodeSelector })
+
+    await storage.generatePreview({
+      cid: 'some-cid',
+      secondOffset: 0,
+      userId: 42
+    })
+
+    const [url] = mockFetch.mock.calls[0]! as [URL]
+    expect(url.search).toBe('')
+  })
+
+  it('throws on a non-ok response', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 401 } as Response)
+    const storage = new Storage({ storageNodeSelector })
+
+    await expect(
+      storage.generatePreview({ cid: 'some-cid', secondOffset: 15 })
+    ).rejects.toThrow('status: 401')
+  })
+})

--- a/packages/sdk/src/sdk/services/Storage/Storage.ts
+++ b/packages/sdk/src/sdk/services/Storage/Storage.ts
@@ -230,7 +230,7 @@ export class Storage implements StorageService {
    * @param {Object} params
    * @param {string} params.cid - The CID of the track to generate a preview for
    * @param {number} params.secondOffset - The offset in seconds to start the preview from
-   * @param {number} params.userId - Decoded id of the user the source audio belongs to
+   * @param {number} [params.userId] - Decoded id of the user the source audio belongs to
    * @returns {Promise<string>} The CID of the generated preview
    */
   async generatePreview({

--- a/packages/web/examples/upload/src/App.tsx
+++ b/packages/web/examples/upload/src/App.tsx
@@ -180,7 +180,10 @@ export default function App() {
 
       // Step 1 — upload audio
       setResult('Uploading audio...')
-      const audioUpload = sdk.uploads.createAudioUpload({ file: audioFile })
+      const audioUpload = sdk.uploads.createAudioUpload({
+        file: audioFile,
+        userId: String(profile.userId ?? profile.sub ?? '') || undefined
+      })
 
       // Step 2 — upload cover art (optional)
       if (coverFile) setResult('Uploading cover art...')

--- a/packages/web/src/store/application/ui/stemsUpload/sagas.ts
+++ b/packages/web/src/store/application/ui/stemsUpload/sagas.ts
@@ -6,6 +6,7 @@ import {
 import { Name, StemCategory } from '@audius/common/models'
 import { publishStems } from '@audius/common/src/api/tan-query/upload/usePublishStems'
 import { getContext, stemsUploadActions } from '@audius/common/store'
+import { Id } from '@audius/sdk'
 import { takeEvery, put, call } from 'typed-redux-saga'
 
 import { make } from 'common/store/analytics/actions'
@@ -35,7 +36,8 @@ function* watchUploadStems() {
         const sdk = await audiusSdk()
         const uploadHandles = uploads.map((stem, index) => {
           return sdk.tracks.uploadTrackFiles({
-            audioFile: stem.file
+            audioFile: stem.file,
+            userId: Id.parse(userId)
           })
         })
         const uploadResponses = await Promise.all(


### PR DESCRIPTION
Stacked on #14552 (which is stacked on #14550). Fixes for the issues found reviewing those two — kept separate so the fixes can be reviewed on their own.

## Bug: stale `userId` closures in `useUpload`

`uploadTrackFiles` and `uploadStemFiles` read `userId` but did not list it in their `useCallback` deps. On a cold load where the upload page renders before `useCurrentAccount` resolves, both callbacks memoize over `userId = undefined` and are never recreated when the account arrives — every upload from that session goes out unsigned. Silent today; once enforcement is on it becomes either a rejected upload or an unclaimable cid. One-line fix in each array.

## Gap: web stems saga never signed

`stemsUpload/sagas.ts` calls `uploadTrackFiles({ audioFile })` with no user, even though the decoded `userId` is already in scope a few lines up. Stems added to an existing track through this flow would publish fine today and fail once the gate opens. Now passes `Id.parse(userId)` like the `useUpload` stem path does.

## Gap: the uploads API surface could not sign at all

Two halves, both fixed:

- `UploadsApi.createAudioUpload` takes an optional encoded `userId` (the form callers hold — both examples pass their OAuth profile id straight through) and threads the decoded id into the file metadata.
- The `Storage` built inside `createSdk` now receives `services.audiusWalletClient`, matching what #14550 did for `createSdkWithServices`. Without this, a wallet-configured SDK still uploaded unsigned through `sdk.uploads`.

Both examples updated to pass the id. As before, no wallet or no id means the upload proceeds unsigned and simply never earns an attestation.

## Cleanups

- `publishTrack` used `decodeHashId(params.userId)` with the schema-parsed `userId` already in scope; now passes the parsed value. (The identical expression in `updateTrack` stays — nothing parsed is in scope there.)
- `generatePreview` JSDoc marks `userId` optional.

## Testing

The vitest failure reported in #14552 (`Object.defineProperty called on non-object` at collection) no longer reproduces — the previously-blocked suites now run and pass. Added `Storage.test.ts` covering `generatePreview`: signed requests carry `signature`/`userId`/`timestamp` query params that recover to the signer against the pinned EIP-712 shape, no-wallet and no-userId requests go out with an empty query string, and non-ok responses throw.

- `packages/sdk`: 13/13 tests pass (`signUpload`, `Storage`, `StorageNodeSelector`), typecheck clean
- `packages/common`, `packages/web`: typecheck clean
- eslint clean on all touched files (the mobile example has 16 pre-existing lint errors untouched by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)