### PR TITLE
fix(edit-track): regenerate the preview when the preview start changes

### DIFF
--- a/packages/common/src/api/tan-query/tracks/useUpdateTrack.ts
+++ b/packages/common/src/api/tan-query/tracks/useUpdateTrack.ts
@@ -152,11 +152,22 @@ export const useUpdateTrack = () => {
         })
       }
 
+      // A changed preview start needs a freshly sliced preview clip. The SDK
+      // only regenerates when asked (and skips it when a new audio file is
+      // uploaded, since transcoding produces the preview then); without this
+      // flag an edit updates preview_start_seconds in metadata while the
+      // track keeps streaming the old preview_cid's clip.
+      const generatePreview =
+        metadataWithSplits.preview_start_seconds != null &&
+        metadataWithSplits.preview_start_seconds !==
+          previousMetadata?.preview_start_seconds
+
       const response = await sdk.tracks.updateTrack({
         audioFile,
         imageFile,
         trackId: Id.parse(trackId),
         userId: Id.parse(userId),
+        generatePreview,
         metadata: sdkMetadata as UpdateTrackRequestBody,
         onProgress: (_, progress) => {
           if (progress.key === 'audio') {


### PR DESCRIPTION
Follow-up bug fix from the content-auth review of #14550/#14552 — independent of the redesign in #14555, works against today's servers.

## The bug

`useUpdateTrack` never passes `generatePreview` to `sdk.tracks.updateTrack`, and the SDK's `updateTrack` only calls `generate_preview` when that flag is set. So editing a gated track's preview start point updates `preview_start_seconds` in the track metadata while the track keeps streaming the old `preview_cid`'s clip — the preview is never re-sliced at the new offset. As far as I can trace, nothing else regenerates it (`populateTrackMetadataWithUploadResponseV2` only touches `previewCid` when a new audio file was uploaded).

## The fix

Pass `generatePreview: true` when the preview start is set and differs from the cached previous track's value:

- The SDK already guards the rest: it skips regeneration when a new `audioFile` is present (transcoding produces the preview then) and when `previewStartSeconds` is undefined.
- A cache miss for the previous track errs toward regenerating, which is idempotent for an unchanged offset.

Once #14555 lands, this call site inherits the attributed `generate_preview` request automatically — `updateTrack` threads its `userId` internally.

## Testing

`packages/common` typechecks clean; eslint clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)