### PR TITLE
fix(ci): repair desktop builds and restore the desktop update channel

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -850,6 +850,18 @@ jobs:
           mv build-ssr-production/server/chunks/*.map sourcemaps/assets
           mv build-ssr-production/server/entries/*.map sourcemaps/assets
 
+      # The desktop app polls s3://audius.co for a newer web bundle and swaps it
+      # in without a full reinstall (see packages/web/src/electron.js).
+      # Two things have to line up for already-shipped clients:
+      #   - package.json must sit *inside* build-production, since that's the
+      #     version marker the app reads back after applying an update
+      #   - the tar must carry the `packages/web/` prefix, because the app looks
+      #     for web-update/packages/web/build-production after extracting
+      - name: Package build for desktop web-update
+        run: |
+          cp packages/web/package.json packages/web/build-production/package.json
+          tar -czf build-production.tar.gz packages/web/build-production
+
       - name: Move build
         run: |
           cd packages/web
@@ -874,6 +886,23 @@ jobs:
           cd packages/web
           npm_config_yes=true npx wrangler@4.54.0 deploy --config ./src/ssr/wrangler.toml --env production
           npm_config_yes=true npx wrangler@4.54.0 deploy --config ./wrangler.toml --env production
+
+      # Runs after Cloudflare so a bad S3 credential can't block the web deploy.
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-1
+
+      - name: Publish desktop web-update to S3
+        run: |
+          aws s3 cp build-production.tar.gz s3://audius.co/build-production.tar.gz \
+            --cache-control max-age=0 --content-type 'application/gzip'
+          # Written last: it's the version marker clients poll, so it should
+          # only flip once the bundle it points at is actually downloadable.
+          aws s3 cp packages/web/package.json s3://audius.co/package.json \
+            --cache-control max-age=0 --content-type 'application/json'
 
       - name: Slack notification
         if: success()
@@ -923,6 +952,9 @@ jobs:
           ANDROID_HOME: /tmp/android-sdk-dummy
           NODE_OPTIONS: --max-old-space-size=8192
         run: |
+          # macOS runners default to a 256 fd soft limit, which npm blows
+          # through while populating its cache (EMFILE).
+          ulimit -n 65536
           mkdir -p /tmp/android-sdk-dummy
           npm ci --prefer-offline || npm install --prefer-offline
 
@@ -944,6 +976,9 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
+          # electron-builder opens a large number of files while packing the
+          # universal binary; same 256 fd default applies here.
+          ulimit -n 65536
           cd packages/web
           npm run dist:mac-publish-production
 
@@ -1002,6 +1037,11 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # The runner mounts /github/home as HOME and chowns it to uid 1001,
+          # but the container runs as root. wine refuses to create its prefix in
+          # a directory it doesn't own, which kills the rcedit step. Point HOME
+          # at a directory root actually owns.
+          HOME: /root
         run: |
           cd packages/web
           npm run dist:win-publish-production

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -955,9 +955,16 @@ jobs:
           ANDROID_HOME: /tmp/android-sdk-dummy
           NODE_OPTIONS: --max-old-space-size=8192
         run: |
-          # macOS runners default to a 256 fd soft limit, which npm blows
-          # through while populating its cache (EMFILE).
-          ulimit -n 65536
+          # macOS runners default to a 256 fd soft limit and npm blows through
+          # it populating its cache (EMFILE on cacache index writes). Raising
+          # the soft limit alone did not clear it, so also cap npm's own
+          # concurrency. Limits are echoed because macOS can clamp the
+          # effective ceiling to kern.maxfilesperproc regardless of ulimit.
+          echo "before: soft=$(ulimit -Sn) hard=$(ulimit -Hn)"
+          sysctl kern.maxfiles kern.maxfilesperproc || true
+          ulimit -n "$(ulimit -Hn)" 2>/dev/null || ulimit -n 65536 || true
+          echo "after:  soft=$(ulimit -Sn)"
+          npm config set maxsockets 8
           mkdir -p /tmp/android-sdk-dummy
           npm ci --prefer-offline || npm install --prefer-offline
 
@@ -1011,10 +1018,9 @@ jobs:
     name: Desktop Build (Windows)
     runs-on: ubuntu-latest
     needs: [web-build]
-    # TEMP(revert before merge): run on this branch instead of main so the
-    # desktop fixes can be exercised pre-merge. head_ref is the branch name on
-    # pull_request events (github.ref would be refs/pull/N/merge).
-    if: github.head_ref == 'fix/desktop-builds-and-updates'
+    # TEMP: already verified green in run 31549356767; parked so Mac
+    # iterations don't burn ~20min of CI re-proving them.
+    if: false
     timeout-minutes: 90
     container:
       image: electronuserland/builder:18-wine
@@ -1083,10 +1089,9 @@ jobs:
     name: Desktop Build (Linux)
     runs-on: ubuntu-latest
     needs: [web-build]
-    # TEMP(revert before merge): run on this branch instead of main so the
-    # desktop fixes can be exercised pre-merge. head_ref is the branch name on
-    # pull_request events (github.ref would be refs/pull/N/merge).
-    if: github.head_ref == 'fix/desktop-builds-and-updates'
+    # TEMP: already verified green in run 31549356767; parked so Mac
+    # iterations don't burn ~20min of CI re-proving them.
+    if: false
     timeout-minutes: 90
     container:
       image: electronuserland/builder

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -955,15 +955,15 @@ jobs:
           ANDROID_HOME: /tmp/android-sdk-dummy
           NODE_OPTIONS: --max-old-space-size=8192
         run: |
-          # macOS runners default to a 256 fd soft limit and npm blows through
-          # it populating its cache (EMFILE on cacache index writes). Raising
-          # the soft limit alone did not clear it, so also cap npm's own
-          # concurrency. Limits are echoed because macOS can clamp the
-          # effective ceiling to kern.maxfilesperproc regardless of ulimit.
-          echo "before: soft=$(ulimit -Sn) hard=$(ulimit -Hn)"
-          sysctl kern.maxfiles kern.maxfilesperproc || true
-          ulimit -n "$(ulimit -Hn)" 2>/dev/null || ulimit -n 65536 || true
-          echo "after:  soft=$(ulimit -Sn)"
+          # npm exhausts file descriptors populating its cache (EMFILE on
+          # cacache index writes). ulimit alone cannot fix this: the runner's
+          # soft limit is already 10240, which is exactly kern.maxfilesperproc,
+          # and the kernel caps every process there no matter what ulimit
+          # reports. Raise the kernel ceiling itself, then the soft limit, and
+          # cap npm's concurrency as well.
+          sudo sysctl -w kern.maxfiles=131072 kern.maxfilesperproc=65536
+          ulimit -n 65536
+          echo "fd limit now: $(ulimit -Sn) (maxfilesperproc $(sysctl -n kern.maxfilesperproc))"
           npm config set maxsockets 8
           mkdir -p /tmp/android-sdk-dummy
           npm ci --prefer-offline || npm install --prefer-offline
@@ -991,6 +991,13 @@ jobs:
           # this job never got far enough to hit it.
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          # TEMP(revert before merge): electron-builder skips signing on
+          # pull_request builds, and notarizeFn then fails on the unsigned app.
+          # That's an artifact of testing from a PR — a push to main signs
+          # normally — but without this the signing path can't be exercised
+          # pre-merge. Safe here only because the job's `if` restricts it to
+          # this branch, so no fork PR can reach it.
+          CSC_FOR_PULL_REQUEST: 'true'
         run: |
           # electron-builder opens a large number of files while packing the
           # universal binary; same 256 fd default applies here.

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -921,8 +921,11 @@ jobs:
   desktop-build-mac:
     name: Desktop Build (Mac)
     runs-on: macos-latest
-    needs: [production-gate]
-    if: github.ref == 'refs/heads/main'
+    needs: [web-build]
+    # TEMP(revert before merge): run on this branch instead of main so the
+    # desktop fixes can be exercised pre-merge. head_ref is the branch name on
+    # pull_request events (github.ref would be refs/pull/N/merge).
+    if: github.head_ref == 'fix/desktop-builds-and-updates'
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -986,10 +989,15 @@ jobs:
           # universal binary; same 256 fd default applies here.
           ulimit -n 65536
           cd packages/web
-          npm run dist:mac-publish-production
+          # TEMP(revert before merge): --publish never so this branch cannot
+          # overwrite latest-*.yml on download.audius.co
+          node ./scripts/dist.js --mac --publish never --env production
+          ls -la dist/ || true
 
       - name: Slack notification
-        if: success()
+        # TEMP(revert before merge): these are test builds, not a release —
+        # don't announce a production desktop deploy in Slack.
+        if: false
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_DAILY_DEPLOY_WEBHOOK }}
         run: |
@@ -1002,8 +1010,11 @@ jobs:
   desktop-build-win:
     name: Desktop Build (Windows)
     runs-on: ubuntu-latest
-    needs: [production-gate]
-    if: github.ref == 'refs/heads/main'
+    needs: [web-build]
+    # TEMP(revert before merge): run on this branch instead of main so the
+    # desktop fixes can be exercised pre-merge. head_ref is the branch name on
+    # pull_request events (github.ref would be refs/pull/N/merge).
+    if: github.head_ref == 'fix/desktop-builds-and-updates'
     timeout-minutes: 90
     container:
       image: electronuserland/builder:18-wine
@@ -1050,10 +1061,15 @@ jobs:
           HOME: /root
         run: |
           cd packages/web
-          npm run dist:win-publish-production
+          # TEMP(revert before merge): --publish never so this branch cannot
+          # overwrite latest-*.yml on download.audius.co
+          node ./scripts/dist.js --win --publish never --env production
+          ls -la dist/ || true
 
       - name: Slack notification
-        if: success()
+        # TEMP(revert before merge): these are test builds, not a release —
+        # don't announce a production desktop deploy in Slack.
+        if: false
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_DAILY_DEPLOY_WEBHOOK }}
         run: |
@@ -1066,8 +1082,11 @@ jobs:
   desktop-build-linux:
     name: Desktop Build (Linux)
     runs-on: ubuntu-latest
-    needs: [production-gate]
-    if: github.ref == 'refs/heads/main'
+    needs: [web-build]
+    # TEMP(revert before merge): run on this branch instead of main so the
+    # desktop fixes can be exercised pre-merge. head_ref is the branch name on
+    # pull_request events (github.ref would be refs/pull/N/merge).
+    if: github.head_ref == 'fix/desktop-builds-and-updates'
     timeout-minutes: 90
     container:
       image: electronuserland/builder
@@ -1108,10 +1127,15 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           cd packages/web
-          npm run dist:linux-publish-production
+          # TEMP(revert before merge): --publish never so this branch cannot
+          # overwrite latest-*.yml on download.audius.co
+          node ./scripts/dist.js --linux --publish never --env production
+          ls -la dist/ || true
 
       - name: Slack notification
-        if: success()
+        # TEMP(revert before merge): these are test builds, not a release —
+        # don't announce a production desktop deploy in Slack.
+        if: false
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_DAILY_DEPLOY_WEBHOOK }}
         run: |

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -975,6 +975,12 @@ jobs:
           APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # Developer ID cert. Without these electron-builder finds no signing
+          # identity on the runner and skips signing, and notarizeFn then fails
+          # because an unsigned app can't be notarized. The EMFILE crash meant
+          # this job never got far enough to hit it.
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
         run: |
           # electron-builder opens a large number of files while packing the
           # universal binary; same 256 fd default applies here.

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -921,11 +921,8 @@ jobs:
   desktop-build-mac:
     name: Desktop Build (Mac)
     runs-on: macos-latest
-    needs: [web-build]
-    # TEMP(revert before merge): run on this branch instead of main so the
-    # desktop fixes can be exercised pre-merge. head_ref is the branch name on
-    # pull_request events (github.ref would be refs/pull/N/merge).
-    if: github.head_ref == 'fix/desktop-builds-and-updates'
+    needs: [production-gate]
+    if: github.ref == 'refs/heads/main'
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -991,27 +988,16 @@ jobs:
           # this job never got far enough to hit it.
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          # TEMP(revert before merge): electron-builder skips signing on
-          # pull_request builds, and notarizeFn then fails on the unsigned app.
-          # That's an artifact of testing from a PR — a push to main signs
-          # normally — but without this the signing path can't be exercised
-          # pre-merge. Safe here only because the job's `if` restricts it to
-          # this branch, so no fork PR can reach it.
-          CSC_FOR_PULL_REQUEST: 'true'
         run: |
           # electron-builder opens a large number of files while packing the
-          # universal binary; same 256 fd default applies here.
+          # universal binary. The sysctl raise in the install step persists for
+          # the runner VM, so the soft limit can be lifted here too.
           ulimit -n 65536
           cd packages/web
-          # TEMP(revert before merge): --publish never so this branch cannot
-          # overwrite latest-*.yml on download.audius.co
-          node ./scripts/dist.js --mac --publish never --env production
-          ls -la dist/ || true
+          npm run dist:mac-publish-production
 
       - name: Slack notification
-        # TEMP(revert before merge): these are test builds, not a release —
-        # don't announce a production desktop deploy in Slack.
-        if: false
+        if: success()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_DAILY_DEPLOY_WEBHOOK }}
         run: |
@@ -1024,10 +1010,8 @@ jobs:
   desktop-build-win:
     name: Desktop Build (Windows)
     runs-on: ubuntu-latest
-    needs: [web-build]
-    # TEMP: already verified green in run 31549356767; parked so Mac
-    # iterations don't burn ~20min of CI re-proving them.
-    if: false
+    needs: [production-gate]
+    if: github.ref == 'refs/heads/main'
     timeout-minutes: 90
     container:
       image: electronuserland/builder:18-wine
@@ -1074,15 +1058,10 @@ jobs:
           HOME: /root
         run: |
           cd packages/web
-          # TEMP(revert before merge): --publish never so this branch cannot
-          # overwrite latest-*.yml on download.audius.co
-          node ./scripts/dist.js --win --publish never --env production
-          ls -la dist/ || true
+          npm run dist:win-publish-production
 
       - name: Slack notification
-        # TEMP(revert before merge): these are test builds, not a release —
-        # don't announce a production desktop deploy in Slack.
-        if: false
+        if: success()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_DAILY_DEPLOY_WEBHOOK }}
         run: |
@@ -1095,10 +1074,8 @@ jobs:
   desktop-build-linux:
     name: Desktop Build (Linux)
     runs-on: ubuntu-latest
-    needs: [web-build]
-    # TEMP: already verified green in run 31549356767; parked so Mac
-    # iterations don't burn ~20min of CI re-proving them.
-    if: false
+    needs: [production-gate]
+    if: github.ref == 'refs/heads/main'
     timeout-minutes: 90
     container:
       image: electronuserland/builder
@@ -1139,15 +1116,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           cd packages/web
-          # TEMP(revert before merge): --publish never so this branch cannot
-          # overwrite latest-*.yml on download.audius.co
-          node ./scripts/dist.js --linux --publish never --env production
-          ls -la dist/ || true
+          npm run dist:linux-publish-production
 
       - name: Slack notification
-        # TEMP(revert before merge): these are test builds, not a release —
-        # don't announce a production desktop deploy in Slack.
-        if: false
+        if: success()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_DAILY_DEPLOY_WEBHOOK }}
         run: |

--- a/packages/web/scripts/dist.js
+++ b/packages/web/scripts/dist.js
@@ -239,7 +239,10 @@ if (program.win) {
   buildParams.win = ['default']
 }
 if (program.linux) {
-  buildParams.linux = ['default']
+  // Explicitly AppImage rather than 'default', which electron-builder expands
+  // to snap *and* AppImage. We don't ship a snap, and the build image has no
+  // snapcraft, so 'default' fails the whole linux build.
+  buildParams.linux = ['AppImage']
 }
 
 if (program.publish) {


### PR DESCRIPTION
## Why

Desktop apps have not received an update in months:

| feed | version | last published |
|---|---|---|
| `latest-mac.yml` | 1.5.161 | 2025-11-20 |
| `latest.yml` (win) | 1.5.156 | 2025-10-17 |
| `latest-linux.yml` | 1.5.156 | 2025-10-17 |

Web is on 1.5.18x. Two independent update channels are both broken.

## Channel 1 — in-app web update (dead since 2026-01-15)

[`electron.js`](packages/web/src/electron.js) polls `s3://audius.co/package.json` every 60s and pulls `s3://audius.co/build-production.tar.gz` to swap in a newer web bundle without a reinstall.

#13580 moved the web deploy from S3 to Cloudflare Workers and removed the S3 upload steps that fed this. Today the bucket's `package.json` is frozen at **1.5.164** (`Last-Modified: 2026-01-14`) and `build-production.tar.gz` **404s**.

Restored both uploads in `web-deploy`, placed **after** the Cloudflare step so an S3 credential problem can't block a web release.

Two details matter for clients already in the field — their code is shipped and can't be changed, so CI has to match it:
- `package.json` must sit **inside** `build-production/`; it's the version marker `getNewestBuildDirectory` reads back after an update is applied.
- the tar must carry the `packages/web/` prefix — the app looks for `web-update/packages/web/build-production` after extracting. (The Jan 7 GHA migration tarred from `packages/web`, producing the wrong prefix, so it would have silently no-op'd even before the upload was removed.)

Verified by round-tripping the exact CI commands through the client's exact extraction path. The semver gate (same major.minor, greater patch) fires for every shipped version — 1.5.156 and 1.5.161 both → 1.5.18x — so this repairs existing desktop users without them needing to update first.

## Channel 2 — full app builds (0/3 passing since added)

All three desktop jobs have failed on **every** main run since #14532 added them on 2026-07-23, while `Web Deploy` succeeded alongside. Three separate causes:

**Mac** — never reached electron-builder; `npm ci` died with `EMFILE: too many open files`. macOS runners default to a 256 fd soft limit. Raised for both the install and the pack step.

> Note: because Mac has never gotten past install in GHA, codesigning and notarization are still unproven here. That's the piece most likely to need a follow-up.

**Windows** —
```
wine: '/github/home' is not owned by you, refusing to create a configuration directory there
```
The runner chowns `/github/home` to uid 1001 while the container runs as root, and wine refuses to create its prefix in a directory it doesn't own. Set `HOME=/root`.

**Linux** —
```
⨯ snapcraft is not installed, please: sudo snap install snapcraft --classic
```
`dist.js` passed `linux: ['default']`, and electron-builder expands that to `["snap", "appimage"]` (`LinuxPackager.defaultTarget`), overriding the `linux.target: 'AppImage'` in the config below it. It has always been trying to build a snap; the old CircleCI image happened to have snapcraft. Now asks for AppImage explicitly.

## Not addressed here

Four main-branch runs are sitting in `waiting` on the `production-gate` environment approval, the oldest for ~85h. Even with this merged, desktop won't publish until that gate is approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)