### PR TITLE
fix(contest): render announcement text with UserGeneratedTextV2

### DIFF
--- a/packages/mobile/src/screens/contest-screen/ContestCommentsList.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestCommentsList.tsx
@@ -36,6 +36,7 @@ import { ActionDrawerWithoutRedux } from '../../components/action-drawer'
 import { Timestamp } from '../../components/comments/Timestamp'
 import { ComposerInput } from '../../components/composer-input'
 import { ProfilePicture } from '../../components/core/ProfilePicture'
+import { UserGeneratedText } from 'app/components/core'
 import { UserLink } from '../../components/user-link'
 
 const messages = {
@@ -475,9 +476,13 @@ const ContestCommentRow = ({
             />
           ) : null}
         </Flex>
-        <Text variant='body' size='s'>
+        <UserGeneratedText
+          variant='body'
+          size='s'
+          mentions={(comment as any).mentions ?? []}
+        >
           {comment.message}
-        </Text>
+        </UserGeneratedText>
         {videoUrl ? (
           <View style={{ marginTop: 4 }}>
             {/* Updates store YouTube / Vimeo URLs (set via the

--- a/packages/mobile/src/screens/contest-screen/ContestCommentsList.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestCommentsList.tsx
@@ -30,13 +30,13 @@ import {
   SelectablePill,
   Text
 } from '@audius/harmony-native'
+import { UserGeneratedText } from 'app/components/core'
 import { VideoEmbed } from 'app/components/video-embed/VideoEmbed'
 
 import { ActionDrawerWithoutRedux } from '../../components/action-drawer'
 import { Timestamp } from '../../components/comments/Timestamp'
 import { ComposerInput } from '../../components/composer-input'
 import { ProfilePicture } from '../../components/core/ProfilePicture'
-import { UserGeneratedText } from 'app/components/core'
 import { UserLink } from '../../components/user-link'
 
 const messages = {
@@ -479,7 +479,7 @@ const ContestCommentRow = ({
         <UserGeneratedText
           variant='body'
           size='s'
-          mentions={(comment as any).mentions ?? []}
+          mentions={comment.mentions ?? []}
         >
           {comment.message}
         </UserGeneratedText>

--- a/packages/web/src/pages/contest-page/components/ContestCommentsSection.tsx
+++ b/packages/web/src/pages/contest-page/components/ContestCommentsSection.tsx
@@ -360,7 +360,11 @@ const ContestCommentRow = ({
           </Text>
         ) : null}
       </Flex>
-      <UserGeneratedTextV2 variant='body' size='m' mentions={(comment as any).mentions ?? []}>
+      <UserGeneratedTextV2
+        variant='body'
+        size='m'
+        mentions={comment.mentions ?? []}
+      >
         {comment.message}
       </UserGeneratedTextV2>
       {videoUrl ? (

--- a/packages/web/src/pages/contest-page/components/ContestCommentsSection.tsx
+++ b/packages/web/src/pages/contest-page/components/ContestCommentsSection.tsx
@@ -23,6 +23,8 @@ import {
 } from '@audius/harmony'
 
 import { UserLink } from 'components/link/UserLink'
+import { UserGeneratedTextV2 } from 'components/user-generated-text/UserGeneratedTextV2'
+import { VideoEmbed } from 'components/video-embed/VideoEmbed'
 
 const messages = {
   heading: 'Contest Feed',
@@ -358,20 +360,13 @@ const ContestCommentRow = ({
           </Text>
         ) : null}
       </Flex>
-      <Text variant='body' size='m'>
+      <UserGeneratedTextV2 variant='body' size='m' mentions={(comment as any).mentions ?? []}>
         {comment.message}
-      </Text>
+      </UserGeneratedTextV2>
       {videoUrl ? (
-        <video
-          controls
-          src={videoUrl}
-          style={{
-            width: '100%',
-            maxHeight: 340,
-            borderRadius: 8,
-            backgroundColor: '#000'
-          }}
-        />
+        <Box mt='xs'>
+          <VideoEmbed url={videoUrl} />
+        </Box>
       ) : null}
     </Paper>
   )

--- a/packages/web/src/pages/contest-page/components/ContestCommentsTile.tsx
+++ b/packages/web/src/pages/contest-page/components/ContestCommentsTile.tsx
@@ -638,7 +638,11 @@ const ContestCommentRow = ({
             </Box>
           ) : null}
         </Flex>
-        <UserGeneratedTextV2 variant='body' size='s' mentions={(comment as any).mentions ?? []}>
+        <UserGeneratedTextV2
+          variant='body'
+          size='s'
+          mentions={comment.mentions ?? []}
+        >
           {comment.message}
         </UserGeneratedTextV2>
         {videoUrl ? (
@@ -868,7 +872,11 @@ const ContestCommentReplyRow = ({
             ) : null}
           </Flex>
         </Flex>
-        <UserGeneratedTextV2 variant='body' size='s' mentions={reply.mentions ?? []}>
+        <UserGeneratedTextV2
+          variant='body'
+          size='s'
+          mentions={reply.mentions ?? []}
+        >
           {reply.message}
         </UserGeneratedTextV2>
         <Flex gap='m' alignItems='center' pt='xs'>

--- a/packages/web/src/pages/contest-page/components/ContestCommentsTile.tsx
+++ b/packages/web/src/pages/contest-page/components/ContestCommentsTile.tsx
@@ -34,6 +34,7 @@ import { useQueryClient } from '@tanstack/react-query'
 
 import { ComposerInput } from 'components/composer-input/ComposerInput'
 import { UserLink } from 'components/link/UserLink'
+import { UserGeneratedTextV2 } from 'components/user-generated-text/UserGeneratedTextV2'
 import { VideoEmbed } from 'components/video-embed/VideoEmbed'
 import { useProfilePicture } from 'hooks/useProfilePicture'
 import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
@@ -637,9 +638,9 @@ const ContestCommentRow = ({
             </Box>
           ) : null}
         </Flex>
-        <Text variant='body' size='s'>
+        <UserGeneratedTextV2 variant='body' size='s' mentions={(comment as any).mentions ?? []}>
           {comment.message}
-        </Text>
+        </UserGeneratedTextV2>
         {videoUrl ? (
           <Box mt='xs'>
             {/* Updates only accept YouTube / Vimeo URLs (set via the
@@ -867,9 +868,9 @@ const ContestCommentReplyRow = ({
             ) : null}
           </Flex>
         </Flex>
-        <Text variant='body' size='s'>
+        <UserGeneratedTextV2 variant='body' size='s' mentions={reply.mentions ?? []}>
           {reply.message}
-        </Text>
+        </UserGeneratedTextV2>
         <Flex gap='m' alignItems='center' pt='xs'>
           <Flex
             gap='xs'


### PR DESCRIPTION
## Problem

Reported by Michael Cullen (Aug 12): when the contest host posts a winner announcement, the rendered text has broken spacing and links are not clickable.

**Root cause:** Both `ContestCommentsTile.tsx` and `ContestCommentsSection.tsx` render `comment.message` with a plain `<Text>` component:
- No `white-space: pre-wrap` → newlines collapse to spaces → **spacing broken**
- No URL parsing → URLs render as inert plain text → **links not clickable**

## Fix

Replace `<Text>{message}</Text>` with `<UserGeneratedTextV2>` in all three message render sites across both components.

`UserGeneratedTextV2` (already used by the track-page comment system) provides:
- `style={{ whiteSpace: 'pre-wrap' }}` — preserves newlines/spacing
- URL detection via regex → renders as clickable `<TextLink>` (external links included — contest announcements routinely link to streams, prize forms, etc.)
- `@mention` detection → renders as clickable profile links

Also fixes `ContestCommentsSection.tsx` broken `<video src={videoUrl}>` → `<VideoEmbed>` for YouTube/Vimeo attached videos (native `<video>` cannot play those URLs; this fix was already applied in `ContestCommentsTile.tsx` but missed in the section component).

## Files changed

- `packages/web/src/pages/contest-page/components/ContestCommentsTile.tsx` — `ContestCommentRow` + `ContestCommentReplyRow`
- `packages/web/src/pages/contest-page/components/ContestCommentsSection.tsx` — `ContestCommentRow` + video embed

## Testing

Post a contest host announcement with:
1. Multiple lines of text → spacing should be preserved
2. A URL (Audius or external) → should be a clickable link
3. A YouTube/Vimeo URL attached as a video → should render the iframe embed
