### PR TITLE
fix(desktop): rebuild the ASC API key PEM before notarizing

### DIFF
--- a/packages/web/scripts/dist.js
+++ b/packages/web/scripts/dist.js
@@ -41,13 +41,37 @@ program
  * Writes the App Store Connect API key (.p8) to a temp file, since notarytool
  * takes a path rather than the key contents. The secret may hold either the raw
  * PEM contents or a base64 encoding of them.
+ *
+ * notarytool parses the .p8 strictly and rejects anything malformed with a bare
+ * `invalidPEMDocument`, which says nothing about what was wrong. Secret stores
+ * mangle PEMs in two routine ways — flattening the newlines to literal `\n`, or
+ * stripping them entirely — so rather than trusting the stored formatting, pull
+ * out the base64 body and rebuild the PEM from scratch.
  * @returns {string} path to the written .p8 file
  */
 const writeApiKeyFile = () => {
   const rawKey = process.env.APP_STORE_CONNECT_API_KEY_KEY
-  const key = rawKey.includes('BEGIN PRIVATE KEY')
+  const decoded = rawKey.includes('BEGIN PRIVATE KEY')
     ? rawKey
     : Buffer.from(rawKey, 'base64').toString('utf8')
+
+  const body = decoded
+    .replace(/-----(BEGIN|END) PRIVATE KEY-----/g, '')
+    .replace(/\\r\\n|\\n/g, '')
+    .replace(/\s/g, '')
+  if (!body || !/^[A-Za-z0-9+/]+={0,2}$/.test(body)) {
+    throw new Error(
+      'APP_STORE_CONNECT_API_KEY_KEY is not a PKCS#8 private key. Expected the ' +
+        'contents of the .p8 downloaded from App Store Connect (or a base64 ' +
+        'encoding of it).'
+    )
+  }
+  const key = [
+    '-----BEGIN PRIVATE KEY-----',
+    ...body.match(/.{1,64}/g),
+    '-----END PRIVATE KEY-----',
+    ''
+  ].join('\n')
 
   const keyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'asc-api-key-'))
   const keyPath = path.join(


### PR DESCRIPTION
## Problem

With the Developer ID signing cert replaced, the Mac desktop build now signs successfully and reaches notarization for the first time — where it fails:

```
• signing  file=dist/mac-arm64/Audius.app  identity=8F3E89764D9E3669B6DE070A9EF8D30373FC1D6A
Error: Failed to notarize via notarytool
Error: invalidPEMDocument
```

`invalidPEMDocument` means notarytool could not parse the `.p8` written from `APP_STORE_CONNECT_API_KEY_KEY`. The key itself is healthy — App Store Connect shows the team key active and in use.

`writeApiKeyFile` trusted the stored formatting whenever the `BEGIN PRIVATE KEY` marker was present. Secret stores commonly flatten PEM newlines to literal `\n` or strip them altogether, both of which keep the marker while producing a file notarytool rejects.

## Fix

Extract the base64 body and rebuild the PEM at 64-column wrapping, so every common storage shape converges on a valid key. When the secret isn't a PKCS#8 key at all, throw an error that says so instead of writing a broken file and letting notarytool report a generic parse failure.

## Testing

Generated a P-256 PKCS#8 key (same shape as an App Store Connect `.p8`) and ran each mangling through the normalizer, checking the result with `openssl pkey -check`:

| Input shape | Result |
|---|---|
| raw PEM (already correct) | PASS |
| literal `\n` escapes | PASS |
| newlines stripped entirely | PASS |
| CRLF line endings | PASS |
| base64 of the PEM | PASS |
| base64 of `\n`-escaped PEM | PASS |
| garbage input | rejected with a clear error |

Note this cannot be verified in CI without merging, since `desktop-build-mac` only runs on `main` behind the production gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)