### PR TITLE
fix(upload): stop the track form wiping description and tags on reinitialize

### DIFF
--- a/packages/web/src/pages/upload-page/forms/UploadTrackForm.test.ts
+++ b/packages/web/src/pages/upload-page/forms/UploadTrackForm.test.ts
@@ -1,0 +1,92 @@
+import { TrackMetadataForUpload } from '@audius/common/store'
+import { describe, expect, it } from 'vitest'
+
+import { getTrackEditInitialMetadata } from './UploadTrackForm'
+
+const makeMetadata = (
+  overrides: Partial<TrackMetadataForUpload> = {}
+): TrackMetadataForUpload =>
+  ({
+    title: 'leftover szn - Run It Back',
+    genre: 'Electronic',
+    ...overrides
+  }) as TrackMetadataForUpload
+
+describe('getTrackEditInitialMetadata', () => {
+  it('seeds blank values for a fresh upload', () => {
+    const result = getTrackEditInitialMetadata(makeMetadata())
+
+    expect(result.description).toBe('')
+    expect(result.tags).toBe('')
+    expect(result.stems).toEqual([])
+    expect(result.isrc).toBe('')
+    expect(result.iswc).toBe('')
+    expect(result.field_visibility).toEqual({
+      genre: true,
+      mood: true,
+      tags: true,
+      share: false,
+      play_count: false,
+      remixes: true
+    })
+  })
+
+  it('seeds from initialMetadata when the track has nothing yet', () => {
+    const result = getTrackEditInitialMetadata(makeMetadata(), {
+      description: 'seeded description',
+      tags: 'seeded,tags'
+    })
+
+    expect(result.description).toBe('seeded description')
+    expect(result.tags).toBe('seeded,tags')
+  })
+
+  // Regression: EditTrackForm runs with `enableReinitialize`, and
+  // `formState.tracks` is rewritten with the user's edits on every submit. When
+  // this function blanked description/tags unconditionally, that reset wiped
+  // them and the track published with no description and no tags.
+  it('preserves user-entered values when the form reinitializes', () => {
+    const edited = makeMetadata({
+      description: 'Stream elsewhere & follow on IG',
+      tags: 'dubstep,bassmusic,bass',
+      isrc: 'USX9P1234567',
+      iswc: 'T-123.456.789-0',
+      stems: [{ metadata: {} } as any],
+      collaborators: [{ user_id: 12345 } as any]
+    })
+
+    const result = getTrackEditInitialMetadata(edited)
+
+    expect(result.description).toBe('Stream elsewhere & follow on IG')
+    expect(result.tags).toBe('dubstep,bassmusic,bass')
+    expect(result.isrc).toBe('USX9P1234567')
+    expect(result.iswc).toBe('T-123.456.789-0')
+    expect(result.stems).toHaveLength(1)
+    expect(result.collaborators).toEqual([{ user_id: 12345 }])
+  })
+
+  it('preserves a user-disabled remixes visibility across reinitialization', () => {
+    const result = getTrackEditInitialMetadata(
+      makeMetadata({
+        field_visibility: {
+          genre: true,
+          mood: true,
+          tags: true,
+          share: false,
+          play_count: false,
+          remixes: false
+        }
+      })
+    )
+
+    expect(result.field_visibility?.remixes).toBe(false)
+  })
+
+  it('is stable across repeated calls so the form does not reset spuriously', () => {
+    const metadata = makeMetadata({ description: 'kept', tags: 'a,b' })
+
+    expect(getTrackEditInitialMetadata(metadata)).toEqual(
+      getTrackEditInitialMetadata(metadata)
+    )
+  })
+})

--- a/packages/web/src/pages/upload-page/forms/UploadTrackForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/UploadTrackForm.tsx
@@ -5,10 +5,12 @@ import {
   TrackForUpload,
   TrackMetadataForUpload
 } from '@audius/common/store'
-import dayjs from 'dayjs'
 
 import { EditTrackForm } from 'components/edit-track/EditTrackForm'
-import { TrackEditFormValues } from 'components/edit-track/types'
+import {
+  SingleTrackEditValues,
+  TrackEditFormValues
+} from 'components/edit-track/types'
 
 type UploadTrackFormProps = {
   formState: TrackFormState
@@ -25,6 +27,41 @@ const defaultHiddenFields = {
   // REMIXES handled by a separate field
 }
 
+/**
+ * Seeds the edit form for one track.
+ *
+ * `EditTrackForm` runs with `enableReinitialize`, so this value is not just the
+ * first render's defaults — Formik resets the whole form to it whenever it
+ * deep-changes. `formState.tracks` is rewritten with the user's edits every
+ * time the form is submitted (see `onSubmit` below, and `EditPage.onContinue`,
+ * which calls `setFormState` while still on the edit phase), so a recompute is
+ * routine rather than exceptional.
+ *
+ * That makes it critical to prefer what's already on `track.metadata` over the
+ * `initialMetadata` seed. Blanking `description`/`tags`/`stems` unconditionally
+ * discarded whatever the user had typed on every reset, and publishing after
+ * that point uploaded a track with an empty description and no tags.
+ */
+export const getTrackEditInitialMetadata = (
+  metadata: TrackMetadataForUpload,
+  initialMetadata?: Partial<TrackMetadataForUpload>
+): SingleTrackEditValues =>
+  ({
+    ...metadata,
+    ...initialMetadata,
+    description: metadata.description ?? initialMetadata?.description ?? '',
+    tags: metadata.tags ?? initialMetadata?.tags ?? '',
+    field_visibility: {
+      ...defaultHiddenFields,
+      ...initialMetadata?.field_visibility,
+      ...metadata.field_visibility,
+      remixes: metadata.field_visibility?.remixes ?? true
+    },
+    stems: metadata.stems ?? initialMetadata?.stems ?? [],
+    isrc: metadata.isrc ?? initialMetadata?.isrc ?? '',
+    iswc: metadata.iswc ?? initialMetadata?.iswc ?? ''
+  }) as SingleTrackEditValues
+
 export const UploadTrackForm = (props: UploadTrackFormProps) => {
   const { formState, onContinue, initialMetadata } = props
   const { tracks } = formState
@@ -33,23 +70,9 @@ export const UploadTrackForm = (props: UploadTrackFormProps) => {
     () => ({
       trackMetadatasIndex: 0,
       tracks: tracks as TrackForUpload[],
-      trackMetadatas: tracks.map((track) => ({
-        ...track.metadata,
-        ...initialMetadata,
-        description: initialMetadata?.description ?? '',
-        releaseDate: initialMetadata?.release_date
-          ? new Date(initialMetadata.release_date)
-          : new Date(dayjs().toString()),
-        tags: initialMetadata?.tags ?? '',
-        field_visibility: {
-          ...defaultHiddenFields,
-          ...initialMetadata?.field_visibility,
-          remixes: true
-        },
-        stems: initialMetadata?.stems ?? [],
-        isrc: initialMetadata?.isrc ?? '',
-        iswc: initialMetadata?.iswc ?? ''
-      }))
+      trackMetadatas: tracks.map((track) =>
+        getTrackEditInitialMetadata(track.metadata, initialMetadata)
+      )
     }),
     [tracks, initialMetadata]
   )


### PR DESCRIPTION
## Summary

Fixes the [#eng report](https://audius-internal.slack.com/archives/CA80RCL77/p1786998980544769): a track published with its description, tags and collaborator all missing right after upload.

`EditTrackForm` runs Formik with `enableReinitialize`, so it resets the whole form whenever `initialValues` deep-changes. `UploadTrackForm` built those values by spreading `track.metadata` and then **hard-overwriting** `description`, `tags`, `stems`, `isrc` and `iswc` with blanks — plus a fresh `new Date()` on every recompute.

`formState.tracks` is rewritten with the user's edits on every submit, and `EditPage.onContinue` calls `setFormState` *while still on the edit phase*, before the upload confirmation modal resolves. So pressing "Complete Upload" recomputes `initialValues` → Formik resets → the typed description and tags are blanked. Publishing from that point uploads an empty description and no tags, while title/genre/mood/artwork survive because they come from the `...track.metadata` spread — and an emptied genre then falls back to the adapter's `DEFAULT_GENRE` (`Electronic`).

## Changes

- Prefer values already on `track.metadata` over the `initialMetadata` seed, so a reinitialize no longer discards user input.
- Preserve a user-disabled `field_visibility.remixes` instead of forcing it back to `true`.
- Drop the `releaseDate` key — it was dead (the adapter reads `release_date`) and minting a `new Date()` on every call guaranteed a reset on every recompute.
- Extract the mapping into an exported `getTrackEditInitialMetadata` so it's unit-testable.

## What this does *not* cover

The "collaborator vanished" half of the report is a separate, arguably-intended behaviour: the API only returns `pending_collaborators` on the requester's own tracks, and `GiantTrackTile` selects only `track.collaborators` (accepted). So a freshly tagged collaborator is invisible on the track page until they accept — even to the owner. Whether the owner should see an "invite pending" chip there is a product call, left alone here.

## Verification

- Ruled out the client transform: ran the real `trackMetadataForUploadToSdk` → `PublishTrackSchema` pipeline with a collaborator present; description, tags and collaborator ids all survive to the on-chain write.
- Ruled out the indexer: `track_create.go` inserts `description`/`tags` unconditionally and reconciles collaborators separately.
- New regression tests in `UploadTrackForm.test.ts` — 2 of the 5 cases fail against the old code and pass with the fix.
- `tsc --noEmit` and `eslint` clean on the touched files.

## Caveat

I could not reproduce the reporter's exact session end-to-end, so this is a mechanism that matches every observed symptom (including the `Electronic` genre fallback and `release_date == created_at`) rather than a confirmed repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)