### PR TITLE
fix(mobile): roll version back to 1.5.185 and drop mobile from changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [
+    "@audius/mobile"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -118865,7 +118865,7 @@
     },
     "packages/mobile": {
       "name": "@audius/mobile",
-      "version": "1.5.186",
+      "version": "1.5.185",
       "dependencies": {
         "@amplitude/analytics-react-native": "1.4.11",
         "@audius/common": "*",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/mobile",
-  "version": "1.5.186",
+  "version": "1.5.185",
   "private": true,
   "scripts": {
     "android:dev": "ENVFILE=.env.dev turbo run android -- --mode=prodDebug",


### PR DESCRIPTION
## Problem

Mobile OTA history is keyed on the **`packages/mobile/package.json` version baked into the JS bundle at build time** ([`src/app/ota-updates.ts`](https://github.com/AudiusProject/apps/blob/main/packages/mobile/src/app/ota-updates.ts)), not on the native version. The client fetches:

```
{OTA_UPDATE_URL}/histories/{platform}/{channel}/{package.json version}.json
```

CI publishes with `--binary-version` = main's package.json version at dispatch time. So an OTA publish only reaches devices whose **shipped store build was compiled from that same package.json version**.

On 2026-08-03, `Version Packages (#14216)` bumped mobile **1.5.185 → 1.5.186**. On that run ([30851065355](https://github.com/AudiusProject/apps/actions/runs/30851065355)) the Android production build uploaded fine but **`iOS Production Build & Upload` failed**, and no iOS production build has run since — later main pushes only trigger OTA jobs, which are gated on `version_changed`.

Result:

- Every iPhone still runs a **1.5.185** bundle and polls `histories/ios/production/1.5.185.json`, whose newest release is from **2026-07-28**. No OTA banner since.
- The two production OTA dispatches on 2026-08-06 ([31128845487](https://github.com/AudiusProject/apps/actions/runs/31128845487), [31131250733](https://github.com/AudiusProject/apps/actions/runs/31131250733)) both reported success and wrote to `production/1.5.186.json` — **orphaned on iOS**, live only for Android users on the 1.5.186 Play build.

The failure is silent by design: the client converts a 404 or empty history into `releaseHistoryNoUpdatePlaceholder` so CodePush doesn't throw. No error, no banner, no signal.

## Change

1. Roll `packages/mobile/package.json` back to **1.5.185** so production OTA publishes target the binary users actually run.
2. Add `@audius/mobile` to the changesets `ignore` list, so the release tooling stops moving what is effectively an OTA routing key (12 mobile changesets are queued on in-flight branches and would re-bump it within days).
3. Sync the `packages/mobile` entry in `package-lock.json`.

## Why this is safe

- **Native versions are independent of this field.** Android `versionName` comes from `build.gradle` (`1.1.534`), `versionCode` from Play's max + 1; iOS build number from `app_store_build_number` + 1. For mobile, `package.json` version is purely an OTA routing key with no store meaning.
- **The triggered production builds don't reach store users.** The rollback reads as `version_changed=true` and fires both production build jobs, but iOS `lane :upload` calls `pilot(...)` (TestFlight, explicitly "Don't actually distribute"), Android's `build_and_upload` no-ops unless `buildFileVersion > releasedVersion`, and both sit behind the `mobile-production-ios` / `mobile-production-android` environment gates.
- **`MIN_APP_VERSION` is not tripped.** [`useUpdateRequired`](https://github.com/AudiusProject/apps/blob/main/packages/mobile/src/hooks/useUpdateRequired.ts) forces an update screen when package.json `semver.lt` the remote value. Default is `1.0.0`, and iPhones run 1.5.185 bundles today with no forced-update screen, so the live value is already ≤ 1.5.185.
- `changeset status` exits 0 with `@audius/mobile` absent from the bump list. `main` currently has only 4 changesets, all `@audius/sdk`, so nothing needs untangling first.

The `## 1.5.186` entry in `packages/mobile/CHANGELOG.md` is left in place — those changes really did ship to rc and to Android.

## Follow-ups (not in this PR)

- **The iOS 1.5.186 production build still needs fixing**, or iOS drifts behind again on the next native release.
- **4 in-flight changesets will break `Version Packages` once mobile is ignored** — changesets throws on any changeset listing both ignored and non-ignored packages. These need the `'@audius/mobile': patch` line dropped before they merge: `ota-version-flag-attribute.md`, `profile-conditional-contests-tab.md`, `remove-fingerprintjs.md`, `rename-chronological-feed-to-latest.md`.
- Consider a CI guard that refuses an OTA publish when no store build exists for the target binary version — today that case is a green checkmark reaching nobody.

## After merge

`mobile-ota-release-production` is `workflow_dispatch`-only and does not depend on `version_unchanged`, so once `current_version` reads 1.5.185 you can dispatch production OTA directly to unblock the ~3 weeks of undelivered JS fixes. A normal main push first gets you an `rc` publish as a canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)