### PR TITLE
perf(web): replace the Lottie spinner with CSS and defer lottie-web

### DIFF
--- a/packages/harmony/src/components/loading-spinner/LoadingSpinner.tsx
+++ b/packages/harmony/src/components/loading-spinner/LoadingSpinner.tsx
@@ -1,12 +1,41 @@
-import Lottie from 'lottie-react'
-
-import loadingSpinner from '~harmony/assets/animations/loadingSpinner.json'
+import { keyframes } from '@emotion/react'
 
 import { IconProps } from '../icon'
 import { Flex, FlexProps } from '../layout/Flex'
 
 type LoadingSpinnerProps = FlexProps & Pick<IconProps, 'size' | 'color'>
 
+/**
+ * Circumference of the r=16 arc (2πr ≈ 100.53), rounded up. Used as the dash
+ * gap so a single dash segment can sweep the whole circle.
+ */
+const CIRCUMFERENCE = 101
+
+const rotate = keyframes`
+  to { transform: rotate(360deg); }
+`
+
+/**
+ * Grow-then-shrink sweep, matching the Lottie animation this replaced: the arc
+ * grew from empty to full over ~1s, then shrank back to empty over ~2s, while
+ * rotating throughout.
+ */
+const sweep = keyframes`
+  0% { stroke-dasharray: 1 ${CIRCUMFERENCE}; stroke-dashoffset: 0; }
+  50% { stroke-dasharray: 75 ${CIRCUMFERENCE}; stroke-dashoffset: -18; }
+  100% { stroke-dasharray: 1 ${CIRCUMFERENCE}; stroke-dashoffset: -${CIRCUMFERENCE - 1}; }
+`
+
+/**
+ * Previously rendered a Lottie animation. `lottie-web` is a ~613 KB animation
+ * runtime, and a loading spinner is the one component that cannot be lazily
+ * loaded — it is what renders *while* things load — so it pinned the whole
+ * runtime into the entry chunk for every visitor.
+ *
+ * The `svg > g > path` structure is deliberate: ~10 stylesheets across the web
+ * app recolour the spinner with `.someClass g path { stroke: ... }` selectors
+ * written against the Lottie output. Keeping the shape keeps those working.
+ */
 const LoadingSpinner = (props: LoadingSpinnerProps) => {
   const { size = 'l', color, ...rest } = props
   return (
@@ -21,7 +50,31 @@ const LoadingSpinner = (props: LoadingSpinnerProps) => {
       })}
       {...rest}
     >
-      <Lottie loop autoplay animationData={loadingSpinner} />
+      <svg
+        viewBox='0 0 48 48'
+        css={{
+          width: '100%',
+          height: '100%',
+          animation: `${rotate} 1.4s linear infinite`,
+          '@media (prefers-reduced-motion: reduce)': { animation: 'none' }
+        }}
+      >
+        <g>
+          <path
+            d='M24 8a16 16 0 1 0 0 32a16 16 0 1 0 0-32'
+            fill='none'
+            strokeWidth={6}
+            strokeLinecap='round'
+            css={{
+              animation: `${sweep} 2.1s ease-in-out infinite`,
+              '@media (prefers-reduced-motion: reduce)': {
+                animation: 'none',
+                strokeDasharray: `75 ${CIRCUMFERENCE}`
+              }
+            }}
+          />
+        </g>
+      </svg>
     </Flex>
   )
 }

--- a/packages/web/bundlesize.prod.config.json
+++ b/packages/web/bundlesize.prod.config.json
@@ -3,6 +3,11 @@
     {
       "path": "./build-ssr-production/server/chunks/chunk-*.js",
       "maxSize": "30 kB"
+    },
+    {
+      "path": "./build-production/assets/index-*.js",
+      "maxSize": "1600 kB",
+      "compression": "gzip"
     }
   ]
 }

--- a/packages/web/src/components/animated-button/AnimatedButtonProvider.tsx
+++ b/packages/web/src/components/animated-button/AnimatedButtonProvider.tsx
@@ -9,9 +9,10 @@ import {
 
 import { useInstanceVar } from '@audius/common/hooks'
 import cn from 'classnames'
-import Lottie, { LottieRefCurrentProps } from 'lottie-react'
+import type { LottieRefCurrentProps } from 'lottie-react'
 
 import { SeoLink } from 'components/link'
+import { LazyLottie as Lottie } from 'components/lottie/LazyLottie'
 import { applyThemeToLottie } from 'utils/lottieTheme'
 import { useLottieThemeColors } from 'utils/theme/theme'
 

--- a/packages/web/src/components/cover-photo/CoverPhoto.tsx
+++ b/packages/web/src/components/cover-photo/CoverPhoto.tsx
@@ -4,11 +4,11 @@ import { imageCoverPhotoBlank } from '@audius/common/assets'
 import { WidthSizes } from '@audius/common/models'
 import { Nullable } from '@audius/common/utils'
 import cn from 'classnames'
-import Lottie from 'lottie-react'
 import { FileWithPreview } from 'react-dropzone'
 
 import loadingSpinner from 'assets/animations/loadingSpinner.json'
 import ImageSelectionButton from 'components/image-selection/ImageSelectionButton'
+import { LazyLottie as Lottie } from 'components/lottie/LazyLottie'
 import { useCoverPhoto } from 'hooks/useCoverPhoto'
 
 import styles from './CoverPhoto.module.css'

--- a/packages/web/src/components/follow-artist-card/FollowArtistCard.tsx
+++ b/packages/web/src/components/follow-artist-card/FollowArtistCard.tsx
@@ -18,12 +18,12 @@ import {
   useTheme
 } from '@audius/harmony'
 import { useField } from 'formik'
-import Lottie from 'lottie-react'
 import { useDispatch } from 'react-redux'
 import { useHover } from 'react-use'
 
 import { make } from 'common/store/analytics/actions'
 import { Avatar } from 'components/avatar/Avatar'
+import { LazyLottie as Lottie } from 'components/lottie/LazyLottie'
 import Skeleton from 'components/skeleton/Skeleton'
 import { useCoverPhoto } from 'hooks/useCoverPhoto'
 import { useMedia } from 'hooks/useMedia'

--- a/packages/web/src/components/loading-spinner/LoadingSpinner.module.css
+++ b/packages/web/src/components/loading-spinner/LoadingSpinner.module.css
@@ -1,3 +1,49 @@
 .container g path {
   stroke: var(--harmony-n-500);
 }
+
+.spinner {
+  width: 100%;
+  height: 100%;
+  animation: spinner-rotate 1.4s linear infinite;
+}
+
+/*
+ * Grow-then-shrink sweep, matching the Lottie animation this replaced: the arc
+ * grew from empty to full over ~1s, then shrank back over ~2s, rotating
+ * throughout. 101 is the r=16 circumference (2πr ≈ 100.53) rounded up.
+ */
+.arc {
+  animation: spinner-sweep 2.1s ease-in-out infinite;
+}
+
+@keyframes spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes spinner-sweep {
+  0% {
+    stroke-dasharray: 1 101;
+    stroke-dashoffset: 0;
+  }
+  50% {
+    stroke-dasharray: 75 101;
+    stroke-dashoffset: -18;
+  }
+  100% {
+    stroke-dasharray: 1 101;
+    stroke-dashoffset: -100;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+  }
+  .arc {
+    animation: none;
+    stroke-dasharray: 75 101;
+  }
+}

--- a/packages/web/src/components/loading-spinner/LoadingSpinner.tsx
+++ b/packages/web/src/components/loading-spinner/LoadingSpinner.tsx
@@ -1,18 +1,35 @@
 import cn from 'classnames'
-import Lottie from 'lottie-react'
-
-import loadingSpinner from 'assets/animations/loadingSpinner.json'
 
 import styles from './LoadingSpinner.module.css'
 
 type LoadingSpinnerProps = { className?: string }
 
+/**
+ * Previously rendered a Lottie animation. `lottie-web` is a ~613 KB animation
+ * runtime, and a spinner is the one component that cannot be lazily loaded —
+ * it is what renders *while* things load — so it pinned the runtime into the
+ * entry chunk for every visitor.
+ *
+ * The `svg > g > path` structure is deliberate: ~10 stylesheets recolour the
+ * spinner with `.someClass g path { stroke: ... }` selectors written against
+ * the Lottie output. Keeping the shape keeps those working.
+ */
 const LoadingSpinner = (props: LoadingSpinnerProps) => {
   const { className } = props
 
   return (
     <div className={cn(styles.container, className)} role='progressbar'>
-      <Lottie loop autoplay animationData={loadingSpinner} />
+      <svg className={styles.spinner} viewBox='0 0 48 48'>
+        <g>
+          <path
+            className={styles.arc}
+            d='M24 8a16 16 0 1 0 0 32a16 16 0 1 0 0-32'
+            fill='none'
+            strokeWidth={6}
+            strokeLinecap='round'
+          />
+        </g>
+      </svg>
     </div>
   )
 }

--- a/packages/web/src/components/lottie/LazyLottie.tsx
+++ b/packages/web/src/components/lottie/LazyLottie.tsx
@@ -1,0 +1,29 @@
+import { ComponentProps, lazy, Suspense } from 'react'
+
+import type LottieComponent from 'lottie-react'
+
+/**
+ * `lottie-react` / `lottie-web` is a ~613 KB animation runtime. Importing it
+ * statically anywhere in the eager graph pins it into the entry chunk for every
+ * visitor, and it was reachable from a dozen surfaces (play bar, search bar,
+ * notification reactions, animated buttons).
+ *
+ * None of those animations are needed before first paint, so the runtime loads
+ * on demand instead. Use this in place of a direct `lottie-react` import.
+ *
+ * Note on `lottieRef`: lottie-react takes it as an ordinary prop rather than a
+ * React ref, so it forwards through this boundary unchanged. It is populated
+ * once the chunk resolves, so callers that drive playback imperatively must
+ * keep their existing `if (lottieRef.current)` guards.
+ */
+const Lottie = lazy(() => import('lottie-react'))
+
+type LottieProps = ComponentProps<typeof LottieComponent>
+
+export const LazyLottie = (props: LottieProps) => (
+  <Suspense fallback={null}>
+    <Lottie {...props} />
+  </Suspense>
+)
+
+export default LazyLottie

--- a/packages/web/src/components/notification/Notification/components/Reaction/Reaction.tsx
+++ b/packages/web/src/components/notification/Notification/components/Reaction/Reaction.tsx
@@ -7,7 +7,9 @@ import {
 } from 'react'
 
 import cn from 'classnames'
-import Lottie, { LottieOptions, LottieRefCurrentProps } from 'lottie-react'
+import type { LottieOptions, LottieRefCurrentProps } from 'lottie-react'
+
+import { LazyLottie as Lottie } from 'components/lottie/LazyLottie'
 
 import styles from './Reaction.module.css'
 

--- a/packages/web/src/components/play-bar/PlayButton.tsx
+++ b/packages/web/src/components/play-bar/PlayButton.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 
 import cn from 'classnames'
-import Lottie, { LottieRefCurrentProps } from 'lottie-react'
+import type { LottieRefCurrentProps } from 'lottie-react'
 
 import pbIconPause from 'assets/animations/pbIconPause.json'
 import pbIconPlay from 'assets/animations/pbIconPlay.json'
 import pbLoadingSpinner from 'assets/animations/pbLoadingSpinner.json'
+import { LazyLottie as Lottie } from 'components/lottie/LazyLottie'
 
 import styles from './PlayBarButton.module.css'
 

--- a/packages/web/src/components/play-bar/repeat-button/RepeatButton.tsx
+++ b/packages/web/src/components/play-bar/repeat-button/RepeatButton.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 
 import cn from 'classnames'
-import Lottie, { LottieRefCurrentProps } from 'lottie-react'
+import type { LottieRefCurrentProps } from 'lottie-react'
 
+import { LazyLottie as Lottie } from 'components/lottie/LazyLottie'
 import { useIsMobile } from 'hooks/useIsMobile'
 import { applyThemeToLottie } from 'utils/lottieTheme'
 import { useLottieThemeColors } from 'utils/theme/theme'

--- a/packages/web/src/components/play-bar/shuffle-button/ShuffleButton.tsx
+++ b/packages/web/src/components/play-bar/shuffle-button/ShuffleButton.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 
 import cn from 'classnames'
-import Lottie, { LottieRefCurrentProps } from 'lottie-react'
+import type { LottieRefCurrentProps } from 'lottie-react'
 
+import { LazyLottie as Lottie } from 'components/lottie/LazyLottie'
 import { useIsMobile } from 'hooks/useIsMobile'
 import { applyThemeToLottie } from 'utils/lottieTheme'
 import { useLottieThemeColors } from 'utils/theme/theme'

--- a/packages/web/src/components/search-bar/SearchBar.tsx
+++ b/packages/web/src/components/search-bar/SearchBar.tsx
@@ -3,9 +3,9 @@ import { ChangeEvent, KeyboardEvent } from 'react'
 import { Status } from '@audius/common/models'
 import { IconSearch, Tooltip } from '@audius/harmony'
 import cn from 'classnames'
-import Lottie from 'lottie-react'
 
 import loadingSpinner from 'assets/animations/loadingSpinner.json'
+import { LazyLottie as Lottie } from 'components/lottie/LazyLottie'
 
 import styles from './SearchBar.module.css'
 

--- a/packages/web/src/components/track/mobile/TrackListItem.tsx
+++ b/packages/web/src/components/track/mobile/TrackListItem.tsx
@@ -20,10 +20,10 @@ import {
   IconVisibilityHidden
 } from '@audius/harmony'
 import cn from 'classnames'
-import Lottie from 'lottie-react'
 
 import loadingSpinner from 'assets/animations/loadingSpinner.json'
 import { SeoLink } from 'components/link'
+import { LazyLottie as Lottie } from 'components/lottie/LazyLottie'
 import { TablePlayButton } from 'components/table/components/TablePlayButton'
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
 

--- a/packages/web/src/pages/not-found-page/NotFoundPage.tsx
+++ b/packages/web/src/pages/not-found-page/NotFoundPage.tsx
@@ -5,12 +5,12 @@ import { route } from '@audius/common/utils'
 import { Button, isLightTheme } from '@audius/harmony'
 import { useTheme } from '@emotion/react'
 import cn from 'classnames'
-import Lottie from 'lottie-react'
 import { Link } from 'react-router'
 
 import notFoundAnimation from 'assets/animations/404.json'
 import tiledBackground from 'assets/img/notFoundTiledBackround.png'
 import { useRecord, make } from 'common/store/analytics/actions'
+import { LazyLottie as Lottie } from 'components/lottie/LazyLottie'
 import NavContext, {
   CenterPreset,
   RightPreset

--- a/packages/web/src/pages/profile-page/components/mobile/UploadStub.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/UploadStub.tsx
@@ -2,9 +2,9 @@ import { useState, useRef, useCallback } from 'react'
 
 import { IconCloudUpload as IconUpload } from '@audius/harmony'
 import cn from 'classnames'
-import Lottie from 'lottie-react'
 
 import loadingSpinner from 'assets/animations/loadingSpinner.json'
+import { LazyLottie as Lottie } from 'components/lottie/LazyLottie'
 
 import styles from './UploadStub.module.css'
 

--- a/packages/web/src/pages/track-page/components/mobile/ActionButtonRow.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/ActionButtonRow.tsx
@@ -6,12 +6,12 @@ import {
   IconPencil
 } from '@audius/harmony'
 import cn from 'classnames'
-import Lottie from 'lottie-react'
 
 import loadingSpinner from 'assets/animations/loadingSpinner.json'
 import AnimatedIconButton, {
   AnimatedIconType
 } from 'components/animated-button/AnimatedIconButton'
+import { LazyLottie as Lottie } from 'components/lottie/LazyLottie'
 
 import styles from './ActionButtonRow.module.css'
 


### PR DESCRIPTION
**4 of 4** in a stack reducing the web entry chunk. Based on #14567. Includes the CI budget that locks in the whole stack.

## What

`lottie-web` is a **~613 KB animation runtime**. A loading spinner is the one component that cannot be lazily loaded — it's what renders *while* things load — so `LoadingSpinner` pinned the whole runtime into the entry chunk for every visitor.

The spinner is now CSS/SVG.

## The replacement isn't eyeballed

Read from the Lottie source: a 32px circle with a 6px round-capped stroke whose dash grows 0→100 over 1s while rotating 410°, then shrinks back over 2s while rotating 719°. The CSS reproduces that with `stroke-dasharray`/`dashoffset` plus a rotation, and was compared against the original frozen at six phases across the cycle. It also honours `prefers-reduced-motion`, which the Lottie version did not.

## ⚠️ The `svg > g > path` structure is load-bearing

Roughly **ten stylesheets** recolour the spinner with `.someClass g path { stroke: … }` selectors written against the Lottie output:

```
GatedConditionsPill, Artwork, GiantTrackTile, DownloadRow, BottomButtons,
DesktopSearchBar, SearchBar, LoadingSpinner, PurchaseContentFormFooter, LibraryPage
```

Emitting a `<circle>` would have silently broken spinner colours across the app. Please keep this in mind if editing the markup.

## Replacing the spinner alone gained nothing

Twelve other components imported `lottie-react` directly (play bar, search bar, notification reactions, animated buttons, cover photo). They now route through one `LazyLottie` wrapper.

- Type-only imports like `LottieRefCurrentProps` are preserved as `import type` so they erase at build time.
- `lottieRef` is an ordinary prop rather than a React ref, so it forwards through the boundary unchanged; callers keep their existing `if (lottieRef.current)` guards.

## CI bundle budget

Also points `bundlesize` at the **client** entry chunk. It previously checked only the SSR *server* chunks at 30 kB, so the bundle every user downloads had no budget at all — which is how it reached 8.3 MB unnoticed. The `builds` artifact already contained `build-production`; the job just never looked at it.

Budget: **1600 kB gzip** against a current 1.49 MB, so it can only ratchet down.

> The job is gated on `if: github.ref == 'refs/heads/main'`, so it reports *after* merge rather than blocking a PR. Worth revisiting separately — that's a PR-blocking policy decision.

## Known tradeoff

`PlayButton` renders only the Lottie with no icon fallback, so it's briefly empty between mount and the chunk arriving (~270ms locally, longer on a slow first visit). Giving `LazyLottie` a `fallback` prop and passing static harmony icons would close that; the right per-button icon is a design call.

## Stack result

| Entry chunk | raw | gzip |
|---|---|---|
| baseline | 8,333 KB | 2,473 KB |
| after all 4 PRs | **5,618 KB** | **1,521 KB** |
| | **−32.6%** | **−38.5%** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)