### PR TITLE
perf(web): keep react-virtualized out of the entry chunk

### DIFF
--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -5,7 +5,9 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  Ref
+  Ref,
+  lazy,
+  Suspense
 } from 'react'
 
 import { CSSObject, useTheme } from '@emotion/react'
@@ -20,8 +22,26 @@ import { Text } from '~harmony/components/text/Text'
 import { useControlled } from '~harmony/hooks/useControlled'
 import { IconCaretDown, IconCloseAlt, IconSearch } from '~harmony/icons'
 
-import { OptionsList, VirtualizedOptionsList } from './FilterButtonOptionsList'
+import { OptionsList } from './FilterButtonOptionsList'
 import { FilterButtonProps } from './types'
+
+/**
+ * `react-virtualized` is ~638 KB of source and is only needed when a consumer
+ * opts in with the `virtualized` prop (3 call sites across the web app). It was
+ * previously a static import, so every surface using FilterButton — and
+ * FilterButton is reachable from the eager app shell via PaymentMethod — paid
+ * for it. Loaded on demand instead; the menu is only rendered while open, so
+ * the import starts when a virtualized filter menu is actually opened.
+ */
+const VirtualizedOptionsList = lazy(() =>
+  import('./FilterButtonVirtualizedOptionsList').then((m) => ({
+    // `lazy()` erases the component's `<Value extends string>` generic, so it
+    // resolves to the `string` instantiation. Re-declaring the generic on the
+    // lazy const keeps call sites type-safe; the generic is erased at runtime
+    // either way, so this only restores what lazy() dropped.
+    default: m.VirtualizedOptionsList as typeof m.VirtualizedOptionsList
+  }))
+) as typeof import('./FilterButtonVirtualizedOptionsList').VirtualizedOptionsList
 
 const messages = {
   noMatches: 'No matches'
@@ -228,13 +248,15 @@ export const FilterButton = forwardRef(function FilterButton<
 
   const optionElements = filteredOptions ? (
     virtualized ? (
-      <VirtualizedOptionsList
-        options={filteredOptions}
-        optionRefs={optionRefs}
-        onChange={handleOptionSelected}
-        height={menuProps?.maxHeight}
-        width={menuProps?.width}
-      />
+      <Suspense fallback={null}>
+        <VirtualizedOptionsList
+          options={filteredOptions}
+          optionRefs={optionRefs}
+          onChange={handleOptionSelected}
+          height={menuProps?.maxHeight}
+          width={menuProps?.width}
+        />
+      </Suspense>
     ) : (
       <OptionsList
         options={filteredOptions}

--- a/packages/harmony/src/components/button/FilterButton/FilterButtonOptionsList.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButtonOptionsList.tsx
@@ -1,7 +1,4 @@
-import { useState, useCallback, useEffect, RefObject } from 'react'
-
-import { CSSObject } from '@emotion/react'
-import { List, ListRowProps } from 'react-virtualized'
+import { RefObject } from 'react'
 
 import { MenuItem } from '~harmony/components/internal/MenuItem'
 import { OptionKeyHandler } from '~harmony/components/internal/OptionKeyHandler'
@@ -14,61 +11,6 @@ type OptionsListProps<Value extends string> = {
   optionRefs: RefObject<HTMLButtonElement[]>
   scrollRef: RefObject<HTMLDivElement | null>
   onChange: (value: Value) => void
-}
-
-type VirtualizedOptionsListProps<Value extends string> = {
-  options: FilterButtonOptionType<Value>[]
-  optionRefs: RefObject<HTMLButtonElement[]>
-  onChange: (value: Value) => void
-  height: CSSObject['height']
-  width: CSSObject['width']
-}
-
-export const VirtualizedOptionsList = <Value extends string>({
-  options,
-  optionRefs,
-  onChange,
-  height = 100,
-  width = 100
-}: VirtualizedOptionsListProps<Value>) => {
-  const [rowHeight, setRowHeight] = useState(50)
-  useEffect(() => {
-    if (optionRefs.current?.[0]) {
-      setRowHeight(optionRefs.current?.[0].offsetHeight)
-    }
-  }, [optionRefs])
-
-  const renderItem = useCallback(
-    ({ index, style }: ListRowProps) => {
-      const option = options[index]
-
-      return (
-        <MenuItem
-          style={style}
-          variant='option'
-          ref={(el) => {
-            if (optionRefs && optionRefs.current && el) {
-              optionRefs.current[index] = el
-            }
-          }}
-          key={option.value}
-          {...option}
-          onChange={onChange}
-        />
-      )
-    },
-    [onChange, optionRefs, options]
-  )
-
-  return (
-    <List
-      width={Number(width)}
-      height={Number(height)}
-      rowCount={options.length}
-      rowHeight={rowHeight}
-      rowRenderer={renderItem}
-    />
-  )
 }
 
 export const OptionsList = <Value extends string>({

--- a/packages/harmony/src/components/button/FilterButton/FilterButtonVirtualizedOptionsList.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButtonVirtualizedOptionsList.tsx
@@ -1,0 +1,63 @@
+import { useState, useCallback, useEffect, RefObject } from 'react'
+
+import { CSSObject } from '@emotion/react'
+import { List, ListRowProps } from 'react-virtualized'
+
+import { MenuItem } from '~harmony/components/internal/MenuItem'
+
+import { FilterButtonOptionType } from './types'
+
+type VirtualizedOptionsListProps<Value extends string> = {
+  options: FilterButtonOptionType<Value>[]
+  optionRefs: RefObject<HTMLButtonElement[]>
+  onChange: (value: Value) => void
+  height: CSSObject['height']
+  width: CSSObject['width']
+}
+
+export const VirtualizedOptionsList = <Value extends string>({
+  options,
+  optionRefs,
+  onChange,
+  height = 100,
+  width = 100
+}: VirtualizedOptionsListProps<Value>) => {
+  const [rowHeight, setRowHeight] = useState(50)
+  useEffect(() => {
+    if (optionRefs.current?.[0]) {
+      setRowHeight(optionRefs.current?.[0].offsetHeight)
+    }
+  }, [optionRefs])
+
+  const renderItem = useCallback(
+    ({ index, style }: ListRowProps) => {
+      const option = options[index]
+
+      return (
+        <MenuItem
+          style={style}
+          variant='option'
+          ref={(el) => {
+            if (optionRefs && optionRefs.current && el) {
+              optionRefs.current[index] = el
+            }
+          }}
+          key={option.value}
+          {...option}
+          onChange={onChange}
+        />
+      )
+    },
+    [onChange, optionRefs, options]
+  )
+
+  return (
+    <List
+      width={Number(width)}
+      height={Number(height)}
+      rowCount={options.length}
+      rowHeight={rowHeight}
+      rowRenderer={renderItem}
+    />
+  )
+}

--- a/packages/web/src/components/audio-transactions-table/AudioTransactionsTable.tsx
+++ b/packages/web/src/components/audio-transactions-table/AudioTransactionsTable.tsx
@@ -61,12 +61,7 @@ const defaultColumns: AudioTransactionsTableColumn[] = [
   'spacer2'
 ]
 
-export const isChangePositive = (tx: TransactionDetails) => {
-  return (
-    tx.transactionType === TransactionType.PURCHASE ||
-    tx.method === TransactionMethod.RECEIVE
-  )
-}
+export { isChangePositive } from './isChangePositive'
 
 // Cell Render Functions
 const renderTransactionTypeCell = (cellInfo: TransactionCell) => {

--- a/packages/web/src/components/audio-transactions-table/isChangePositive.ts
+++ b/packages/web/src/components/audio-transactions-table/isChangePositive.ts
@@ -1,0 +1,21 @@
+import {
+  TransactionDetails,
+  TransactionMethod,
+  TransactionType
+} from '@audius/common/store'
+
+/**
+ * Whether a transaction increases the user's balance.
+ *
+ * Lives in its own module rather than in `AudioTransactionsTable` so that
+ * consumers needing only this predicate don't pull in the table — which imports
+ * `components/table` and, through it, `react-virtualized` (~638 KB of source).
+ * `TransactionDetailsContent` is reachable from the eagerly-registered
+ * TransactionDetails modal, so that edge landed the whole table in the entry chunk.
+ */
+export const isChangePositive = (tx: TransactionDetails) => {
+  return (
+    tx.transactionType === TransactionType.PURCHASE ||
+    tx.method === TransactionMethod.RECEIVE
+  )
+}

--- a/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
@@ -21,7 +21,7 @@ import {
 import cn from 'classnames'
 
 import { AudioTransactionIcon } from 'components/audio-transaction-icon'
-import { isChangePositive } from 'components/audio-transactions-table/AudioTransactionsTable'
+import { isChangePositive } from 'components/audio-transactions-table/isChangePositive'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { getChallengeConfig } from 'pages/rewards-page/config'
 


### PR DESCRIPTION
Replaces #14566, which GitHub closed when a force-push (rebasing off the now-merged #14565) orphaned the head SHA it had recorded. Same branch, same content — now a clean 6-file diff against `main`.

**2 of 4** in a stack reducing the web entry chunk. #14565 is merged; this is next.

## What

`react-virtualized` is ~638 KB of source and was landing in the entry chunk for every visitor through **two unrelated edges**, neither of which needs it at first paint.

### 1. FilterButton imported it statically

It only renders `VirtualizedOptionsList` behind the opt-in `virtualized` prop — **3 call sites** in the whole web app. Split into its own module, loaded on demand behind a Suspense boundary. The menu only renders while open, so the import starts when a virtualized filter menu is actually opened.

FilterButton is reachable from the eager app shell via `PaymentMethod`, which is why this landed in the entry chunk rather than a lazy page.

> Note the `as typeof import(...)` on the lazy const: `React.lazy` erases the component's `<Value extends string>` generic, so it would otherwise resolve to the `string` instantiation and lose type safety at call sites.

### 2. A five-line predicate

`TransactionDetailsContent` imported `isChangePositive` — a function that checks two enum values — from `AudioTransactionsTable`. That module imports `components/table`, which imports `react-virtualized`. Because the TransactionDetails modal is registered eagerly in `registerNiceModals`, the entire virtualized table came along for this:

```ts
export const isChangePositive = (tx: TransactionDetails) => {
  return (
    tx.transactionType === TransactionType.PURCHASE ||
    tx.method === TransactionMethod.RECEIVE
  )
}
```

Moved to its own module, re-exported from the table for backwards compatibility.

## Verification

`react-virtualized` confirmed absent from the entry chunk via sourcemap attribution. Web tests pass (152), typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)