### PR TITLE
ci(embed): deploy the embed player from main

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'packages/web/**'
+      - 'packages/embed/**'
       - 'packages/common/**'
       - 'packages/harmony/**'
       - 'packages/libs/**'
@@ -15,6 +16,7 @@ on:
   pull_request:
     paths:
       - 'packages/web/**'
+      - 'packages/embed/**'
       - 'packages/common/**'
       - 'packages/harmony/**'
       - 'packages/libs/**'
@@ -914,6 +916,103 @@ jobs:
           job_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           json_content="{ \"blocks\": [{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed production <${job_url}|v${deploying_version}> to web \n\" } }]}"
           curl -f -X POST -H 'Content-type: application/json' --data "$json_content" $SLACK_WEBHOOK
+
+  # Ported from the CircleCI `embed-deploy-production-cloudflare` job, which was
+  # dropped with the rest of .circleci in #14504 and never replaced - leaving the
+  # embed player with no deploy path at all. Unlike the old job (which only ran
+  # on release* branches) this deploys straight from main, and unlike the web
+  # deploy it isn't behind the production gate: the embed is a self-contained
+  # player with no desktop/S3 half to coordinate with.
+  embed-deploy:
+    name: Embed Deploy
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Upgrade npm to 11.10.0
+        run: npm install -g npm@11.10.0
+
+      - name: Create concatenated patch file
+        id: patch-file
+        run: |
+          ls -d -- packages/*/patches/*.patch 2>/dev/null | xargs cat > combined-patch-file.txt || touch combined-patch-file.txt
+          echo "patch_checksum=$(sha256sum combined-patch-file.txt | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/embed/node_modules
+            packages/harmony/node_modules
+            packages/common/node_modules
+            packages/libs/node_modules
+            packages/sdk/node_modules
+          key: npm-cache-${{ runner.os }}-node-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}-${{ steps.patch-file.outputs.patch_checksum }}
+          restore-keys: |
+            npm-cache-${{ runner.os }}-node-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}-
+
+      - name: Install dependencies (if cache miss)
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        env:
+          CI: true
+          SKIP_POD_INSTALL: true
+          SKIP_ANDROID_INSTALL: true
+          ANDROID_HOME: /tmp/android-sdk-dummy
+          NODE_OPTIONS: --max-old-space-size=8192
+        run: |
+          mkdir -p /tmp/android-sdk-dummy
+          npm cache clean --force || true
+          npm ci --prefer-offline || npm install --prefer-offline
+
+      - name: Run postinstall (if cache hit)
+        if: steps.cache-node-modules.outputs.cache-hit == 'true'
+        env:
+          CI: true
+          SKIP_POD_INSTALL: true
+          SKIP_ANDROID_INSTALL: true
+          ANDROID_HOME: /tmp/android-sdk-dummy
+          NODE_OPTIONS: --max-old-space-size=8192
+        run: |
+          mkdir -p /tmp/android-sdk-dummy
+          npm run postinstall
+
+      # `build:prod` runs turbo, which builds the harmony/sdk dists first, then
+      # renames build/ to build-production/.
+      - name: Build embed
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+        run: |
+          cd packages/embed
+          npm run build:prod
+
+      - name: Install workers-site dependencies
+        run: |
+          cd packages/embed/workers-site
+          npm i
+
+      # wrangler.toml's [site] bucket points at ./build, so undo the rename that
+      # build:prod just did. The old CircleCI job did exactly this - the split
+      # is why `build:prod && deploy:prod` deploys nothing on its own.
+      - name: Move build
+        run: |
+          cd packages/embed
+          mv build-production build
+
+      - name: Deploy to Cloudflare (Production)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          cd packages/embed
+          npm_config_yes=true npx wrangler@4.54.0 deploy --env production
 
   # Desktop (Electron) builds. electron-builder reads packages/web/build-production
   # directly (see packages/web/scripts/dist.js), so the `builds` artifact is

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -9,7 +9,7 @@
     "build": "vite build",
     "build:prod": "env-cmd -f .env.prod turbo run build && npm run build-api && mv build build-production",
     "build-api": "webpack --config src/api/webpack.config.js -o build/api.js",
-    "deploy:prod": "npx wrangler publish --env production",
+    "deploy:prod": "wrangler deploy --env production",
     "test": "jest",
     "lint:fix": "eslint --cache --fix --ext=js,jsx,ts,tsx src",
     "lint": "eslint --cache --ext=js,jsx,ts,tsx src",

--- a/packages/embed/wrangler.toml
+++ b/packages/embed/wrangler.toml
@@ -1,11 +1,13 @@
 compatibility_date = "2023-11-06"
-type = "webpack"
 account_id = "3811365464a8e56b2b27a5590e328e49"
 workers_dev = true
 
+# `main` replaces the old `[site] entry-point`, and the wrangler-1.x
+# `type = "webpack"` field is gone - wrangler bundles the worker itself now.
+main = "workers-site/index.js"
+
 [site]
 bucket = "./build"
-entry-point = "workers-site"
 
 [env.test]
 name = "test"


### PR DESCRIPTION
The embed player has had **no deploy path since 2026-06-23**. CircleCI shipped it via `embed-deploy-production-cloudflare`; #14504 deleted `.circleci` without porting that job, and nothing in `.github/` has referenced `packages/embed` since. The package README still says "Deployed via CI".

Caught because #14571 sat merged for four days with the old bundle still serving on `audius.co/embed`.

## The port

Adds an `embed-deploy` job to `web.yml`. Three deliberate differences from the CircleCI original:

| | CircleCI | here |
|---|---|---|
| trigger | `release*` branches | `main` |
| gate | none | none (see below) |
| deploy cmd | `npm run deploy:prod` | `npx wrangler@4.54.0 deploy`, matching the web deploy |

Not behind the `production` gate that web and desktop share. The embed is a self-contained player with no desktop/S3 half to coordinate with, and gating it would mean the deploy that just rotted for two months needs a human every time. Easy to add `needs: [production-gate]` if you'd rather it wait.

Also adds `packages/embed/**` to the workflow path filters — without it an embed-only change doesn't trigger this workflow at all, which is why #14571 ran no CI beyond the security scanners.

## Two fixes it depends on

- **`wrangler.toml` was wrangler-1.x era.** `type = "webpack"` is silently ignored and `[site] entry-point` is deprecated; both replaced with a top-level `main`. Verified with `--dry-run` on the pinned 3.30.1 *and* 4.54.0 — clean on both, warnings on neither.
- **`deploy:prod` called `wrangler publish`**, which no longer exists in wrangler 4. So the manual deploy documented in the README was already broken on any current wrangler. Now `wrangler deploy --env production`.

The odd-looking build/deploy split is preserved, not fixed: `build:prod` renames `build/` → `build-production/` and the deploy job renames it back, because `[site] bucket` points at `./build`. That split across repo and CI is why `build:prod && deploy:prod` deploys nothing on its own. Worth collapsing someday; left alone here to keep this a port.

## Verification

Ran the job's exact step sequence locally: `npm run build:prod` → `workers-site npm i` → `mv build-production build` → `npx wrangler@4.54.0 deploy --env production --dry-run`. Uploads 57.95 KiB, zero warnings. Confirmed the built bundle contains #14571's strings, so this would ship the fix that's currently stuck.

Only thing not verifiable without merging: that `secrets.CLOUDFLARE_API_TOKEN` (already used by the web deploy in this same workflow) has access to the `embed` worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)