### PR TITLE
fix(mobile): make the Android glass surface fully opaque

### DIFF
--- a/packages/mobile/src/components/core/Screen/GlassSurface.tsx
+++ b/packages/mobile/src/components/core/Screen/GlassSurface.tsx
@@ -21,14 +21,22 @@ import { isDarkTheme, useThemeColors, useThemeVariant } from 'app/utils/theme'
 const IOS_TINT_OPACITY = 0.72
 
 /**
- * Android does not get a real backdrop blur. `@react-native-community/blur`'s
- * Android implementation is expensive enough to drop frames on a surface that
- * is composited on every scroll frame, and the existing app-wide precedent
- * (ProfileNavOverlay) already falls back to a solid fill there. We use a high
- * -opacity tint instead: content still slides under the header, it just isn't
- * blurred while it does.
+ * Android does not get a real backdrop blur — `@react-native-community/blur`'s
+ * Android implementation is expensive enough to drop frames on a surface
+ * composited on every scroll frame — so the surface is fully opaque there,
+ * matching the existing `ProfileNavOverlay` fallback.
+ *
+ * It is opaque rather than *nearly* opaque on purpose. Translucency only reads
+ * as frost when something blurs what shows through; with no blur, whatever
+ * bleeds through keeps its edges and reads as legible ghost text sitting on
+ * top of the header. A previous 0.94 looked acceptable in light mode (~8%
+ * relative contrast) but broke badly in dark: 6% of near-white content over a
+ * near-black surface is a ~93% luminance jump, leaving track titles and play
+ * counts clearly readable behind the header. Any single alpha that suits one
+ * theme is wrong for the other, so Android trades the hint of translucency for
+ * a clean surface. Content still slides under it — it just isn't see-through.
  */
-const ANDROID_TINT_OPACITY = 0.94
+const ANDROID_TINT_OPACITY = 1
 
 /**
  * Scroll distance (px) over which the bottom edge fades from invisible to


### PR DESCRIPTION
Follow-up to #14575, from the Android pass. **This is a real defect in what we just merged.**

## The bug

Android has no backdrop blur, so `GlassSurface` fell back to a `0.94` tint to keep a hint of translucency. That only works in light mode.

Translucency reads as *frost* when something blurs what shows through. With no blur, whatever bleeds through keeps its edges and reads as legible ghost text sitting on top of the header. And the same alpha lands completely differently depending on the surface:

| | glass | ghost peak | relative contrast |
|---|---|---|---|
| Light | RGB 248 | 229 | ~8% |
| Dark | RGB 14 | 27 | **~93%** |

6% of near-white content over a near-black surface nearly doubles the luminance. In dark mode, track titles, artists, durations and play counts were plainly readable behind the header.

## The fix

Android is now fully opaque — which is what the `ProfileNavOverlay` fallback this was meant to follow already does (`backgroundColor: backgroundSurface`, no opacity). I cited that precedent in #14575 and then didn't actually follow it; that was the bug.

No single alpha suits both themes, so Android trades the hint of translucency for a clean surface. Content still slides under the header, it just isn't see-through. **iOS is unchanged** and keeps its real blur.

## Verification

Built `assembleProdDebug` and ran on a Pixel 8 Pro (API 35) emulator in dark mode with real content scrolled behind the header — the surface is now clean, and content clips at the glass edge instead of bleeding through. `tsc` 0 errors, `eslint` clean.

Also confirmed on Android during the same pass, unchanged by this fix: tab bar position/elevation and z-order against the play bar, now-playing drawer and left nav drawer; auto-hide of both bars; and content offset (at max scroll the last item lands exactly at the play bar top).

## Known, not addressed here

The play bar doesn't participate in auto-hide, so hiding the chrome mid-playback leaves it floating with an empty band beneath it. Not Android-specific and pre-existing from #14575 — worth a separate change if we want the bottom chrome to move as one unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)