### PR TITLE
feat(mobile): hide the play bar with the rest of the bottom chrome

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -17,7 +17,15 @@ import type {
   GestureResponderEvent,
   PanResponderGestureState
 } from 'react-native'
-import { Keyboard, Platform, View, StatusBar, Pressable } from 'react-native'
+import {
+  Keyboard,
+  Platform,
+  View,
+  StatusBar,
+  Pressable,
+  StyleSheet
+} from 'react-native'
+import Reanimated, { useAnimatedStyle } from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import TrackPlayer from 'react-native-track-player'
 import { useDispatch, useSelector } from 'react-redux'
@@ -33,6 +41,7 @@ import { useDrawer } from 'app/hooks/useDrawer'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { AppDrawerContext } from 'app/screens/app-drawer-screen'
 import { AppTabNavigationContext } from 'app/screens/app-screen'
+import { useTabBarHiddenProgress } from 'app/screens/app-screen/TabBarAutoHideContext'
 import { makeStyles } from 'app/styles'
 import { zIndex } from 'app/utils/zIndex'
 
@@ -110,6 +119,7 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
   const styles = useStyles()
 
   const { isOpen, onOpen, onClose } = useDrawer('NowPlaying')
+  const tabBarHidden = useTabBarHiddenProgress()
   // Defer to the comments bottom-sheet while it's presented: its swipe-to-dismiss
   // gesture would otherwise leak through and also close this drawer underneath.
   const { isOpen: isCommentDrawerOpen } = useCommentDrawer()
@@ -169,6 +179,31 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
   const effectiveTopInset =
     isOpen && isDrawerFullyOpen ? staticTopInset.current : insets.top
   const effectiveBottomInset = isOpen && isDrawerFullyOpen ? 0 : insets.bottom
+
+  // Travel with the bottom tab bar so the bottom chrome moves as one unit.
+  // The collapsed drawer rests `BOTTOM_BAR_HEIGHT + PLAY_BAR_HEIGHT` off the
+  // bottom, so once the tab bar floats away the play bar would otherwise hang
+  // there with an empty band beneath it.
+  //
+  // This moves the whole drawer rather than just the play bar inside it: the
+  // white surface behind the play bar belongs to the drawer root, so
+  // translating only its contents slides the bar off a background that stays
+  // put, leaving an empty white block. Pinned to 0 while open, since the same
+  // drawer is the full-screen player and translating that would drag the
+  // expanded player off screen with it.
+  const chromeHideStyle = useAnimatedStyle(
+    () => ({
+      transform: [
+        {
+          translateY: isOpen
+            ? 0
+            : (PLAY_BAR_HEIGHT + BOTTOM_BAR_HEIGHT + insets.bottom) *
+              tabBarHidden.value
+        }
+      ]
+    }),
+    [isOpen, insets.bottom]
+  )
 
   useEffect(() => {
     if (
@@ -281,79 +316,94 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
   }, [onClose, navigation, trackId])
 
   return (
-    <Drawer
-      // Appears below bottom bar whereas normally drawers appear above
-      zIndex={zIndex.NOW_PLAYING_DRAWER}
-      isOpen={isOpen}
-      onClose={onClose}
-      onOpen={onDrawerOpen}
-      initialOffsetPosition={BOTTOM_BAR_HEIGHT + PLAY_BAR_HEIGHT}
-      shouldCloseToInitialOffset={isPlayBarShowing}
-      animationStyle={DrawerAnimationStyle.SPRINGY}
-      shouldBackgroundDim={false}
-      shouldShowShadow={!isInChatScreen}
-      shouldAnimateShadow={false}
-      drawerStyle={{ overflow: 'visible' }}
-      onPercentOpen={onDrawerPercentOpen}
-      onPanResponderMove={onPanResponderMove}
-      onPanResponderRelease={onPanResponderRelease}
-      isGestureSupported={isGestureEnabled}
-      gesturesDisabled={isCommentDrawerOpen}
-      translationAnim={translationAnim}
-      // Disable safe area view edges because they are handled manually
-      disableSafeAreaView
+    // Wrapping the drawer creates a new stacking context, so its own z-order
+    // has to be restated out here. `box-none` keeps the full-screen wrapper
+    // from swallowing touches meant for the screen behind it.
+    <Reanimated.View
+      pointerEvents='box-none'
+      style={[
+        StyleSheet.absoluteFill,
+        { zIndex: zIndex.NOW_PLAYING_DRAWER },
+        chromeHideStyle
+      ]}
     >
-      <View
-        style={[
-          styles.container,
-          { paddingTop: effectiveTopInset, paddingBottom: effectiveBottomInset }
-        ]}
+      <Drawer
+        // Appears below bottom bar whereas normally drawers appear above
+        zIndex={zIndex.NOW_PLAYING_DRAWER}
+        isOpen={isOpen}
+        onClose={onClose}
+        onOpen={onDrawerOpen}
+        initialOffsetPosition={BOTTOM_BAR_HEIGHT + PLAY_BAR_HEIGHT}
+        shouldCloseToInitialOffset={isPlayBarShowing}
+        animationStyle={DrawerAnimationStyle.SPRINGY}
+        shouldBackgroundDim={false}
+        shouldShowShadow={!isInChatScreen}
+        shouldAnimateShadow={false}
+        drawerStyle={{ overflow: 'visible' }}
+        onPercentOpen={onDrawerPercentOpen}
+        onPanResponderMove={onPanResponderMove}
+        onPanResponderRelease={onPanResponderRelease}
+        isGestureSupported={isGestureEnabled}
+        gesturesDisabled={isCommentDrawerOpen}
+        translationAnim={translationAnim}
+        // Disable safe area view edges because they are handled manually
+        disableSafeAreaView
       >
-        <View style={styles.playBarContainer}>
-          <PlayBar
-            mediaKey={`${mediaKey}`}
-            duration={trackDuration}
-            track={track}
-            user={user}
-            onPress={onDrawerOpen}
-            translationAnim={translationAnim}
-          />
-        </View>
-        <Logo translationAnim={translationAnim} />
-        <View style={styles.titleBarContainer}>
-          <TitleBar onClose={onClose} />
-        </View>
-        <Pressable onPress={handlePressTitle} style={styles.artworkContainer}>
-          <Artwork track={track} />
-        </Pressable>
-        <View style={styles.trackInfoContainer}>
-          <TrackInfo
-            onPressTitle={handlePressTitle}
-            track={track}
-            user={user}
-          />
-        </View>
-        <View style={styles.scrubberContainer}>
-          <Scrubber
-            mediaKey={`${mediaKey}`}
-            isPlaying={isPlaying && !isBuffering}
-            onPressIn={onPressScrubberIn}
-            onPressOut={onPressScrubberOut}
-            duration={trackDuration}
-          />
-        </View>
-        <View style={styles.controlsContainer}>
-          <AudioControls
-            onNext={onNext}
-            onPrevious={onPrevious}
-            isLongFormContent={
-              track?.genre === Genre.Podcasts ||
-              track?.genre === Genre.Audiobooks
+        <View
+          style={[
+            styles.container,
+            {
+              paddingTop: effectiveTopInset,
+              paddingBottom: effectiveBottomInset
             }
-          />
-          <ActionsBar track={track} />
+          ]}
+        >
+          <View style={styles.playBarContainer}>
+            <PlayBar
+              mediaKey={`${mediaKey}`}
+              duration={trackDuration}
+              track={track}
+              user={user}
+              onPress={onDrawerOpen}
+              translationAnim={translationAnim}
+            />
+          </View>
+          <Logo translationAnim={translationAnim} />
+          <View style={styles.titleBarContainer}>
+            <TitleBar onClose={onClose} />
+          </View>
+          <Pressable onPress={handlePressTitle} style={styles.artworkContainer}>
+            <Artwork track={track} />
+          </Pressable>
+          <View style={styles.trackInfoContainer}>
+            <TrackInfo
+              onPressTitle={handlePressTitle}
+              track={track}
+              user={user}
+            />
+          </View>
+          <View style={styles.scrubberContainer}>
+            <Scrubber
+              mediaKey={`${mediaKey}`}
+              isPlaying={isPlaying && !isBuffering}
+              onPressIn={onPressScrubberIn}
+              onPressOut={onPressScrubberOut}
+              duration={trackDuration}
+            />
+          </View>
+          <View style={styles.controlsContainer}>
+            <AudioControls
+              onNext={onNext}
+              onPrevious={onPrevious}
+              isLongFormContent={
+                track?.genre === Genre.Podcasts ||
+                track?.genre === Genre.Audiobooks
+              }
+            />
+            <ActionsBar track={track} />
+          </View>
         </View>
-      </View>
-    </Drawer>
+      </Drawer>
+    </Reanimated.View>
   )
 })


### PR DESCRIPTION
Follow-up to #14575. The now-playing bar didn't participate in the auto-hide, so scrolling down with a track playing left it stranded — the tab bar floats away beneath it and the play bar stayed put with an empty band underneath.

It now travels on the same `useTabBarHiddenProgress` the tab bar uses, so the two move as one unit rather than on two signals that can drift.

## Why the whole drawer moves, not the play bar

My first attempt translated just the play bar. Both bars hid — and it left an **empty white band** instead. The white surface behind the play bar belongs to the drawer root, so moving only its contents slid the bar off a background that stayed put. Same problem, different colour.

So this moves the drawer. Two consequences worth reviewing:

- **Wrapping the drawer creates a new stacking context**, so its z-order is restated on the wrapper, and `pointerEvents='box-none'` keeps the full-screen wrapper from swallowing touches meant for the screen behind it. This is the same class of thing the tab bar work already had to handle.
- **Pinned to `0` while the drawer is open** — that same drawer is the full-screen player, and translating it there would drag the expanded player off screen.

## Verification (iOS simulator, track actually playing)

- Chrome hides and restores as one unit, no empty band.
- Full-screen player still opens correctly through the wrapper.
- Swipe-to-dismiss still works.
- Left nav drawer still pushes the play bar with the screen rather than being punctured by its elevation — the specific z-order risk of wrapping.
- No crashes across the run.

`tsc` 0 errors, `eslint` clean.

## Not verified

**Android.** This is a shared, gesture-heavy component and Android resolves z-order via `elevation` rather than `zIndex`, which is exactly where the wrapper could behave differently. Worth an Android check before or shortly after merge.

## Unrelated, but noticed

Two `SIGABRT`s occurred on the simulator during this session, both `ShadowTree::commit` asserts inside `reanimated::ReanimatedMountHook::shadowTreeDidMount`. Both followed Fast Refresh reload cycles; clean launches have been stable through playback, scrolling, drawer open/close and tab switching. Likely a dev-only artifact — that assert is typically compiled out in release — but noting it since it first appeared during the #14575 reanimated work rather than before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)