### PR TITLE
fix(mobile): render Discover Weekly as a lineup with a header tile

### DIFF
--- a/packages/mobile/src/screens/discover-weekly-screen/DiscoverWeeklyScreen.tsx
+++ b/packages/mobile/src/screens/discover-weekly-screen/DiscoverWeeklyScreen.tsx
@@ -95,48 +95,52 @@ export const DiscoverWeeklyScreen = () => {
     })
   }, [trackIds.length, trackEvent])
 
+  const header = (
+    <Flex ph='l' pt='l'>
+      <Paper row gap='l' alignItems='center' p='l'>
+        <Image
+          source={discoverWeeklyArt}
+          style={{ width: ART_SIZE, height: ART_SIZE, borderRadius: 8 }}
+        />
+        <Flex column gap='xs' style={{ flex: 1 }}>
+          <Text variant='title' size='l'>
+            {exploreMessages.discoverWeekly}
+          </Text>
+          <Text variant='body' size='s' color='subdued'>
+            {exploreMessages.discoverWeeklySubtitle}
+          </Text>
+          {trackIds.length ? (
+            <Text variant='body' size='s' color='subdued'>
+              {exploreMessages.discoverWeeklyTrackCount(trackIds.length)}
+            </Text>
+          ) : null}
+          <Button
+            variant='primary'
+            size='small'
+            iconLeft={isPlaying ? IconPause : IconPlay}
+            onPress={handlePlay}
+            disabled={!trackIds.length}
+          >
+            {isPlaying ? 'Pause' : 'Play'}
+          </Button>
+        </Flex>
+      </Paper>
+    </Flex>
+  )
+
   return (
     <Screen title={messages.title} topbarRight={null} variant='secondary'>
       <ScreenContent>
-        <Paper m='l' gap='l' h='100%'>
-          <Flex row gap='l' alignItems='center' p='l'>
-            <Image
-              source={discoverWeeklyArt}
-              style={{ width: ART_SIZE, height: ART_SIZE, borderRadius: 8 }}
-            />
-            <Flex column gap='xs' style={{ flex: 1 }}>
-              <Text variant='title' size='l'>
-                {exploreMessages.discoverWeekly}
-              </Text>
-              <Text variant='body' size='s' color='subdued'>
-                {exploreMessages.discoverWeeklySubtitle}
-              </Text>
-              {trackIds.length ? (
-                <Text variant='body' size='s' color='subdued'>
-                  {exploreMessages.discoverWeeklyTrackCount(trackIds.length)}
-                </Text>
-              ) : null}
-              <Button
-                variant='primary'
-                size='small'
-                iconLeft={isPlaying ? IconPause : IconPlay}
-                onPress={handlePlay}
-                disabled={!trackIds.length}
-              >
-                {isPlaying ? 'Pause' : 'Play'}
-              </Button>
-            </Flex>
-          </Flex>
-          <TrackLineup
-            trackIds={trackIds}
-            source='DISCOVER_WEEKLY_TRACKS'
-            isPending={isPending}
-            isFetching={isFetching}
-            hasNextPage={false}
-            loadNextPage={() => {}}
-            pageSize={30}
-          />
-        </Paper>
+        <TrackLineup
+          trackIds={trackIds}
+          source={DISCOVER_WEEKLY_SOURCE}
+          isPending={isPending}
+          isFetching={isFetching}
+          hasNextPage={false}
+          loadNextPage={() => {}}
+          pageSize={30}
+          header={header}
+        />
       </ScreenContent>
     </Screen>
   )


### PR DESCRIPTION
## What

The native Discover Weekly screen wrapped the artwork header **and** the entire track list in one `<Paper m='l' h='100%'>`, so the whole page read as a single full-page tile with the lineup nested inside it.

This moves the header into the lineup's `ListHeaderComponent` so it renders as a normal lineup with a header tile on top — same shape as Trending / Remixes / Listening History.

- Header (art, title, subtitle, track count, play button) is its own `Paper` tile, passed via `TrackLineup`'s `header` prop.
- `TrackLineup` now renders directly under `ScreenContent`, so track tiles sit on the screen background.
- Header padded `ph='l' pt='l'` to line up with `TrackLineup`'s own 16px item padding.
- Swapped the duplicated `'DISCOVER_WEEKLY_TRACKS'` string literal for the existing `DISCOVER_WEEKLY_SOURCE` constant already used for the playback queue.

Follow-up to #14574.

## Testing

`tsc` and eslint clean for `packages/mobile`. Layout-only change — no behavior, playback, or analytics changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)