### PR TITLE
fix(web): stop album tracks rendering a 12/31/69 date

### DIFF
--- a/packages/web/src/pages/collection-page/useCollectionPage.ts
+++ b/packages/web/src/pages/collection-page/useCollectionPage.ts
@@ -161,7 +161,11 @@ export const useCollectionPage = (
           kind: Kind.TRACKS,
           id: trackId,
           uid: makeStableUid(Kind.TRACKS, trackId, COLLECTION_TRACKS_SOURCE),
-          dateAdded: dayjs.unix(time)
+          // `time` is 0 for entries whose added-timestamp was never written to
+          // playlist_contents. `dayjs.unix(0)` renders as 12/31/69 and, being a
+          // truthy object, also defeats the `dateAdded || created_at` fallback
+          // downstream — so fall back to the track's creation date here.
+          dateAdded: time ? dayjs.unix(time) : dayjs(t.created_at)
         } as CollectionTrack
       })
       .filter((e): e is CollectionTrack => e !== null)


### PR DESCRIPTION
## Problem

Tracks inside albums render their date as **12/31/69**. Reported by Michael from support email ([Slack](https://audius-internal.slack.com/archives/CA80RCL77/p1787942604832019)), with three examples:

- https://audius.co/SIRMYKE/album/cabanne-place-vocals-single
- https://audius.co/chillhopmusic/album/chillhop-essentials-summer-2026
- https://audius.co/hullabalo0/album/celestial-groove-the-new-view-2008-2011

## Root cause

The API is returning `playlist_contents[].timestamp: 0` for exactly the rows that render as 1969 — a long-standing data condition, not new:

```
celestial  [(EvGyvNo, 0), (XBxbjPR, 1787595758), (rbNjPNY, 0), (qJp7xva, 0), ...]
UI          Prophecy 12/31/69 | Tommy 8/24/26 | Skullthor 12/31/69 | Jungle Punch 12/31/69
```

What changed is that the client stopped defending against it. The legacy collection lineup saga only assigned `dateAdded` when the timestamp was non-zero:

```js
// packages/web/src/common/store/pages/collection/lineups/sagas.js (deleted)
if (times[i]) {
  metadata.dateAdded = dayjs.unix(times[i])
}
```

leaving it `undefined` on a zero so the downstream fallback fired:

```ts
date: metadata.dateAdded || metadata.created_at
```

#14178 ("Drop legacy lineup system") rewrote this tan-query-first and dropped the guard, always assigning `dayjs.unix(time)`. `dayjs.unix(0)` is a truthy object, so the `|| created_at` fallback in both `formatMetadata` and the mobile `CollectionPage` became dead code.

**Albums only**, as reported, because `desktop/CollectionPage.tsx` picks the column by type — `isAlbum ? 'date' : 'addedDate'` — and `date` is the one carrying the dead fallback.

## Fix

Restore the intent at the source, so desktop and mobile both pick it up:

```ts
dateAdded: time ? dayjs.unix(time) : dayjs(t.created_at)
```

## Note for review

`onReorderTracks` writes `dateAdded.unix()` back on-chain. With this change, reordering an affected album persists the track's `created_at` instead of `0` — a heal rather than a corruption, but it is a write side-effect of a display fix and worth a conscious ack. (The prior code path would have written the `0` straight back.)

No regression test: `useCollectionPage` has no existing test harness and pulls in the redux store, tan-query and the playback slice, so covering this one-line fallback would mean standing up substantial mocking.

## Separate follow-up

Why some `playlist_contents` entries never get a `time` written is a server-side question this PR does not address. `canonicalizePlaylistEntry` in go-openaudio's ETL only emits `time` when the client sends one, with no block-time default — worth its own look.

## Test plan

- [x] `tsc --noEmit` on `packages/web` — no errors in `collection-page` (remaining errors are pre-existing unbuilt-workspace noise)
- [ ] Load the three album links above and confirm dates render as the track's creation date rather than 12/31/69
- [ ] Confirm a playlist (not album) still shows its "Added" column correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
