### PR TITLE
fix(account): stop signing in deactivated accounts

### DIFF
--- a/packages/common/src/store/account/sagas.test.ts
+++ b/packages/common/src/store/account/sagas.test.ts
@@ -1,0 +1,69 @@
+import { expectSaga } from 'redux-saga-test-plan'
+import * as matchers from 'redux-saga-test-plan/matchers'
+import { describe, it, vitest } from 'vitest'
+
+import { getWalletAccountSaga } from '~/api'
+import { AccountUserMetadata } from '~/models'
+
+import { fetchAccountAsync } from './sagas'
+import { fetchAccountFailed, fetchAccountSucceeded, signedIn } from './slice'
+
+const wallet = '0xc12f8e8a40b90e5aedf58fb729fa543e9a020cb0'
+
+const makeAccount = (isDeactivated: boolean) =>
+  ({
+    user: {
+      user_id: 1,
+      handle: 'test',
+      name: 'Test',
+      is_deactivated: isDeactivated
+    },
+    playlists: [],
+    playlist_library: { contents: [] },
+    track_save_count: 0
+  }) as unknown as AccountUserMetadata
+
+const runFetchAccount = (account: AccountUserMetadata) => {
+  const sdk = {
+    services: {
+      audiusWalletClient: {
+        getAddresses: vitest.fn().mockResolvedValue([wallet])
+      }
+    }
+  }
+
+  return expectSaga(fetchAccountAsync, {
+    shouldMarkAccountAsLoading: true
+  }).provide([
+    [matchers.getContext('audiusSdk'), vitest.fn().mockResolvedValue(sdk)],
+    [matchers.getContext('audiusBackendInstance'), {}],
+    [matchers.getContext('remoteConfigInstance'), { setUserId: vitest.fn() }],
+    [
+      matchers.getContext('localStorage'),
+      {
+        getAudiusUserWalletOverride: vitest.fn().mockResolvedValue(null),
+        getItem: vitest.fn().mockResolvedValue(null),
+        setAudiusAccount: vitest.fn(),
+        setAudiusAccountUser: vitest.fn()
+      }
+    ],
+    [
+      matchers.getContext('queryClient'),
+      { setQueryData: vitest.fn(), getQueryData: vitest.fn() }
+    ],
+    [matchers.call.fn(getWalletAccountSaga), account]
+  ])
+}
+
+describe('fetchAccountAsync', () => {
+  // Regression test: the deactivated branch used to fall through to
+  // fetchAccountSucceeded/signedIn, so a deactivated user was signed back in
+  // on any app load despite the sign-in form rejecting them.
+  it('does not sign in a deactivated account', async () => {
+    await runFetchAccount(makeAccount(true))
+      .put(fetchAccountFailed({ reason: 'ACCOUNT_DEACTIVATED' }))
+      .not.put.actionType(fetchAccountSucceeded.type)
+      .not.put.actionType(signedIn.type)
+      .silentRun()
+  })
+})

--- a/packages/common/src/store/account/sagas.ts
+++ b/packages/common/src/store/account/sagas.ts
@@ -216,6 +216,7 @@ export function* fetchAccountAsync({
         reason: 'ACCOUNT_DEACTIVATED'
       })
     )
+    return
   }
 
   const guestEmailFromLocalStorage = yield* call(

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -839,6 +839,10 @@ function* signIn(action: ReturnType<typeof signOnActions.signIn>) {
       yield* put(
         make(Name.SIGN_IN_WITH_DEACTIVATED_ACCOUNT, { handle: user.handle })
       )
+      // The hedgehog login above already persisted a session. Clear it, or a
+      // refresh will restore the deactivated account via fetchAccount.
+      const authService = yield* getContext('authService')
+      yield* call([authService, authService.signOut])
       yield* put(signOnActions.signInFailed('Account is deactivated'))
       yield* put(toastActions.toast({ content: messages.deactivatedAccount }))
       return


### PR DESCRIPTION
## Description

A user who deactivated their account (`audius.co/timitamminen`, `is_deactivated: true` in prod) reported they can still log in, and sent a screenshot of their own feed from "inside my deactivated account".

Two things combine:

1. **`fetchAccountAsync` is missing a `return`.** It detects the deactivated account, dispatches `resetAccount()` + `fetchAccountFailed({ reason: 'ACCOUNT_DEACTIVATED' })`, and then falls straight through to `setLocalStorageAccountAndUser`, `fetchAccountSucceeded` and `signedIn`. The account is fully restored — and written to local storage — despite the "failure". The `return` was present in the old `packages/web/src/common/store/account/sagas.js` and was dropped when the saga was ported to TS in #10447 (Nov 2024). The sibling cached path `fetchLocalAccountAsync` still guards correctly, which is why this only bites on the network path.

2. **The sign-in saga leaves the hedgehog session live.** `signIn` correctly detects `is_deactivated` and toasts, but by then `authService.signIn` has already persisted the wallet. A page refresh then runs `fetchAccountAsync`, hits (1), and signs the user in. Now calls `authService.signOut` before bailing.

`packages/common` is shared, so this affected both web and mobile.

## Tests

Adds `packages/common/src/store/account/sagas.test.ts` — asserts a deactivated account produces `fetchAccountFailed` and never `fetchAccountSucceeded`/`signedIn`. Verified it fails with the `return` removed.

## How to test

1. Deactivate a test account.
2. Sign in with it — expect the "account deactivated" toast.
3. Reload the page. Before: signed into the feed. After: still signed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)