### PR TITLE
fix(mobile): don't offer share-to-story for a track with no audio

### DIFF
--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -195,8 +195,10 @@ export type TrackMetadata = {
   is_available: boolean
   /**
    * Whether the API will serve audio for this track. The API sets it to false
-   * when the track is deleted or its owner is no longer active (a self
-   * deactivation or a trusted-notifier delist). Optional because not every
+   * when the track is deleted, when its owner is no longer active (a self
+   * deactivation or a trusted-notifier delist), or when the row carries no
+   * track_cid - an upload that transcoded fine but was indexed without the cid
+   * pointing at the audio, leaving nothing to play. Optional because not every
    * track source populates it, so treat `undefined` as "no opinion" rather
    * than as "not streamable".
    */

--- a/packages/common/src/utils/trackAvailability.ts
+++ b/packages/common/src/utils/trackAvailability.ts
@@ -7,10 +7,12 @@ type MaybeTrack = Pick<TrackMetadata, 'is_delete' | 'is_streamable'> &
  * Whether a track should be shown as no longer available.
  *
  * The API reports this via `is_streamable`, which it sets to false when the
- * track is deleted or its owner is no longer active - either because the
+ * track is deleted, when its owner is no longer active - either because the
  * artist deactivated their own account or because the account was delisted by
- * the trusted notifier. Deleted tracks are excluded here because they have
- * their own, more specific "deleted by artist" treatment.
+ * the trusted notifier - or when the row has no track_cid, an upload that was
+ * indexed without the cid pointing at its audio. Deleted tracks are excluded
+ * here because they have their own, more specific "deleted by artist"
+ * treatment.
  *
  * The check is an explicit `=== false` on purpose: not every track source
  * populates `is_streamable`, and an absent field must not be read as

--- a/packages/mobile/src/components/share-drawer/ShareDrawer.tsx
+++ b/packages/mobile/src/components/share-drawer/ShareDrawer.tsx
@@ -160,11 +160,18 @@ export const ShareDrawer = NiceModal.create(() => {
     }
   }, [dispatch, content, source])
 
+  // The story platforms build a video out of the track's audio, so a track with
+  // nothing to play cannot be shared to them. `is_streamable` is false for an
+  // upload that was indexed without its track_cid: the stream URL 404s, ffmpeg
+  // fails on it, and the user gets a bare "something went wrong" with no idea
+  // why. Compare against `false` explicitly - an absent field means the source
+  // did not populate it, not that the track is broken.
   const isShareableTrack =
     content?.type === 'track' &&
     !content.track.is_unlisted &&
     !content.track.is_invalid &&
     !content.track.is_delete &&
+    content.track.is_streamable !== false &&
     !isStreamGatedTrack
 
   const performActionAndClose = useCallback(

--- a/packages/mobile/src/components/share-drawer/useShareToStory.tsx
+++ b/packages/mobile/src/components/share-drawer/useShareToStory.tsx
@@ -366,16 +366,25 @@ export const useShareToStory = ({
         // For simplicity, assume that calculating dominant colors and generating the sticker takes 20% of the total loading time:
         dispatch(setProgress(20))
 
-        const { data, signature } =
-          await audiusBackendInstance.signGatedContentRequest({
-            sdk
+        // Nothing here was guarded before, so a rejection - a failed signature,
+        // an SDK that never initialized - escaped as an unhandled promise
+        // rejection: no toast, and the progress drawer left spinning forever.
+        let streamMp3Url: string
+        try {
+          const { data, signature } =
+            await audiusBackendInstance.signGatedContentRequest({
+              sdk
+            })
+          streamMp3Url = await sdk.tracks.getTrackStreamUrl({
+            trackId: Id.parse(content.track.track_id),
+            userId: OptionalId.parse(userId),
+            userSignature: signature,
+            userData: data
           })
-        const streamMp3Url = await sdk.tracks.getTrackStreamUrl({
-          trackId: Id.parse(content.track.track_id),
-          userId: OptionalId.parse(userId),
-          userSignature: signature,
-          userData: data
-        })
+        } catch (e) {
+          handleError(platform, e, 'Error at resolve stream url step')
+          return
+        }
         const storyVideoPath = path.join(
           RNFS.TemporaryDirectoryPath,
           `storyVideo-${uuid()}.mp4`


### PR DESCRIPTION
## What happened

[Michael reported](https://audius-internal.slack.com/archives/CA80RCL77/p1788456292567669) that one specific link failed with "Sorry, something went wrong" when sharing to an Instagram story, while every other link worked.

That track has no audio. `track_cid` is null on the indexed row, so the stream endpoint 404s. Share-to-story builds a video out of the track's audio — it resolves the stream URL and passes it to ffmpeg as an input (`-i ${streamMp3Url}`). ffmpeg gets a 404 JSON body instead of an mp3, exits non-zero, and `handleError` shows the generic toast with no hint that the track itself is broken. Every other link he tried worked because those tracks had audio.

## What this changes

**Don't offer the story platforms for a track with nothing to play.** AudiusProject/api#1032 makes the API report `is_streamable: false` for these rows, so `isShareableTrack` now excludes them — better than failing 60% of the way through a progress drawer. The check is an explicit `!== false` because not every track source populates the field, and an absent one must not hide the share options.

**Guard the stream-URL step.** `signGatedContentRequest` and `getTrackStreamUrl` were wrapped in nothing at all, and `handleShare` doesn't catch either — so a rejection there (a failed signature, an SDK that never initialized) escaped as an unhandled promise rejection: no toast, and the progress drawer left spinning with no way out but backing out of it. Now it goes through `handleError` like every other step, and the analytics error carries `Error at resolve stream url step` so the failing step is identifiable.

The two comment updates in `packages/common` bring the `is_streamable` docs in line with its widened meaning — it now also covers an upload indexed without its `track_cid`, not just deleted/deactivated.

## Worth knowing

`isTrackUnavailable` reads the same flag, so once the API change lands, these tracks will render the "no longer available" screen on the track page instead of a dead player. That's intended, and transient for tracks the repair job in AudiusProject/api#1032 can fix.

Mobile ships via OTA and iOS OTA has been broken since the 1.5.186 build failed, so this is likely to reach iOS well after the server-side fixes land. The repair job closes the loop regardless of client version.

## Testing

Lint clean on all four files; typecheck clean on the changed files. Not exercised on a device — the share-to-story path needs a real Instagram hand-off to test end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)