### PR TITLE
fix(sdk): don't accept a transcode as done without its cid

### DIFF
--- a/packages/sdk/src/sdk/services/Storage/Storage.test.ts
+++ b/packages/sdk/src/sdk/services/Storage/Storage.test.ts
@@ -50,3 +50,81 @@ describe('generatePreview', () => {
     ).rejects.toThrow('status: 401')
   })
 })
+
+// A storage node can answer `done` from an upload row it has not finished
+// replicating, with no transcode results on it yet. Accepting that response
+// writes a track whose trackCid is undefined: the upload "succeeds" into a
+// track that can never be played, with no error raised anywhere.
+describe('pollProcessingStatus', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  const statusResponse = (body: unknown) =>
+    ({ ok: true, json: async () => body }) as unknown as Response
+
+  const poll = (storage: Storage, template: string) =>
+    (
+      storage as unknown as {
+        pollProcessingStatus: (
+          id: string,
+          template: string,
+          total: number
+        ) => Promise<{ results: Record<string, string> }>
+      }
+    ).pollProcessingStatus('upload-1', template, 1)
+
+  const nodeSelector = {
+    getSelectedNode: async () => 'https://node.example.com',
+    triedSelectingAllNodes: () => false
+  } as unknown as StorageNodeSelectorService
+
+  it('keeps polling when a node reports done with no transcode result', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        statusResponse({ id: 'upload-1', status: 'done', results: {} })
+      )
+      .mockResolvedValueOnce(
+        statusResponse({
+          id: 'upload-1',
+          status: 'done',
+          results: { '320': 'QmTranscoded' }
+        })
+      )
+
+    const storage = new Storage({ storageNodeSelector: nodeSelector })
+    const resp = await poll(storage, 'audio')
+
+    expect(resp.results['320']).toBe('QmTranscoded')
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  }, 20000)
+
+  it('returns immediately once the transcode result is present', async () => {
+    mockFetch.mockResolvedValue(
+      statusResponse({
+        id: 'upload-1',
+        status: 'done',
+        results: { '320': 'QmTranscoded' }
+      })
+    )
+
+    const storage = new Storage({ storageNodeSelector: nodeSelector })
+    const resp = await poll(storage, 'audio')
+
+    expect(resp.results['320']).toBe('QmTranscoded')
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  // Image resizes have no '320' result to wait for; the gate is audio-only.
+  it('does not require a 320 result for image templates', async () => {
+    mockFetch.mockResolvedValue(
+      statusResponse({ id: 'upload-1', status: 'done', results: {} })
+    )
+
+    const storage = new Storage({ storageNodeSelector: nodeSelector })
+    const resp = await poll(storage, 'img_square')
+
+    expect(resp.results).toEqual({})
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/sdk/src/sdk/services/Storage/Storage.ts
+++ b/packages/sdk/src/sdk/services/Storage/Storage.ts
@@ -222,6 +222,9 @@ export class Storage implements StorageService {
     const start = Date.now()
     let lastProgressUpdate = Date.now()
     let lastTranscodeProgress = 0
+    // Tracks whether we ever saw a `done` response with no usable transcode
+    // result, so the timeout can say which of the two failures this was.
+    let sawDoneWithoutResults = false
 
     const maxPollingMs =
       template === 'audio'
@@ -254,7 +257,26 @@ export class Storage implements StorageService {
           })
         }
         if (resp?.status === 'done') {
-          return resp
+          // `done` alone is not proof the transcode results are here. Upload
+          // rows replicate across storage nodes, and getProcessingStatus talks
+          // to whichever node is selected, so a mirror can answer `done` from a
+          // row it has not finished catching up on. Accepting that response
+          // hands populateTrackMetadataWithUploadResponse a `results` map with
+          // no '320' key, the track entity gets written with an undefined
+          // trackCid, and the upload succeeds into a track that can never be
+          // played - no error anywhere, just a dead track with a live page.
+          //
+          // Keep polling instead. A node that really is finished will have the
+          // cid on the next pass, and in the genuinely stuck case this times
+          // out loudly rather than silently publishing unplayable audio.
+          if (template === 'audio' && !resp.results?.['320']) {
+            sawDoneWithoutResults = true
+            this.logger.warn(
+              `Storage node reported done with no transcode results, still polling. id=${id}`
+            )
+          } else {
+            return resp
+          }
         }
         if (resp?.status === 'error') {
           throw new Error(
@@ -278,6 +300,11 @@ export class Storage implements StorageService {
       await wait(POLL_STATUS_INTERVAL)
     }
 
+    if (sawDoneWithoutResults) {
+      throw new Error(
+        `Upload reported done but no transcode result appeared within ${maxPollingMs}ms. id=${id}`
+      )
+    }
     throw new Error(`Upload took over ${maxPollingMs}ms. id=${id}`)
   }
 


### PR DESCRIPTION
## The root cause behind the dead-track incident

[Michael reported](https://audius-internal.slack.com/archives/CA80RCL77/p1788456292567669) that one link failed when sharing to an Instagram story. The track behind it has no audio at all: `track_cid` is null on the indexed row, `/stream` 404s, and share-to-story hands that URL to ffmpeg, which fails. AudiusProject/api#1032 makes the API honest about it and repairs the rows; AudiusProject/apps#14584 stops mobile offering a story for a track it cannot build a video from. **This PR is why the rows exist in the first place.**

`pollProcessingStatus` returned the moment a storage node reported `status: 'done'`:

```ts
if (resp?.status === 'done') {
  return resp
}
```

It never checked that the result it is polling *for* is on the response. Upload rows replicate across storage nodes and `getProcessingStatus` talks to whichever node `storageNodeSelector` hands back — falling over to others on error — so a mirror can legitimately answer `done` from a row it has not finished catching up on, with an empty `results` map.

`populateTrackMetadataWithUploadResponseV2` then does:

```ts
trackCid: audioResponse.results['320'],
```

which is `undefined`, and the track entity is written without a cid. Nothing errors. The upload reports success, the track page loads, the artwork renders, people favorite and repost it — and there is no cid on the row pointing at the audio, so it can never be played and never records a play.

That matches the failing track exactly: `duration`, `bpm`, `musical_key`, `orig_file_cid` and `audio_upload_id` were all populated from the upload response, so the response was there and carried `probe` and `audio_analysis_results` — only `results['320']` was missing. The result: **0 plays against 18 favorites and 16 reposts.**

## The change

Require the `'320'` result before treating an audio poll as finished. A node that really is done will have it on the next pass three seconds later. An upload genuinely stuck in that state now times out with an error naming the cause — `Upload reported done but no transcode result appeared within...` — instead of silently publishing unplayable audio, which is a strictly better failure: the artist finds out at upload time rather than never.

Image templates are untouched; they have no `'320'` to wait for.

## Testing

`Storage.test.ts`: a node reporting done with no results keeps polling and picks up the cid on the retry; a response that already has the cid returns on the first call with no extra poll; image templates return immediately on an empty results map. All 5 tests in the file pass.

Not reproduced against a live node — the race needs replication lag between storage nodes to trigger.

## Related

- AudiusProject/api#1032 — `is_streamable` honesty plus a repair job for rows already in this state
- AudiusProject/apps#14584 — mobile stops offering share-to-story for tracks with no audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)