### PR TITLE
fix(web): bring album Price & Audience back into the inline collection editor

### DIFF
--- a/packages/web/src/components/collection/desktop/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/desktop/CollectionHeader.tsx
@@ -36,6 +36,7 @@ import { CollectionActionButtons } from './CollectionActionButtons'
 import styles from './CollectionHeader.module.css'
 import { EditableCollectionDescription } from './EditableCollectionDescription'
 import { EditableCollectionTitle } from './EditableCollectionTitle'
+import { InlineAlbumPriceAndAudience } from './edit-mode/InlineAlbumPriceAndAudience'
 import { usePlaylistEditMode } from './edit-mode/PlaylistEditModeContext'
 
 const { editPlaylist } = cacheCollectionsActions
@@ -311,7 +312,11 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
       borderTop='strong'
       borderBottom='strong'
     >
-      {isStreamGated && streamConditions ? (
+      {isEditingThis && isAlbumFromCollection ? (
+        // Albums can be switched between free and pay-to-unlock while editing.
+        // This takes the place of the gated-content banner until Apply.
+        <InlineAlbumPriceAndAudience collectionId={collectionId} />
+      ) : isStreamGated && streamConditions ? (
         <GatedContentSection
           isLoading={isLoading}
           contentId={collectionId}

--- a/packages/web/src/components/collection/desktop/edit-mode/InlineAlbumPriceAndAudience.test.tsx
+++ b/packages/web/src/components/collection/desktop/edit-mode/InlineAlbumPriceAndAudience.test.tsx
@@ -1,0 +1,65 @@
+import { act } from '@testing-library/react'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, vi } from 'vitest'
+
+import { testCollection } from 'test/mocks/fixtures/collections'
+import { mockCollectionById } from 'test/msw/mswMocks'
+import { it, render, screen, waitFor } from 'test/test-utils'
+
+import { InlineAlbumPriceAndAudience } from './InlineAlbumPriceAndAudience'
+import {
+  PlaylistEditModeProvider,
+  usePlaylistEditMode
+} from './PlaylistEditModeContext'
+
+vi.mock('services/analytics', () => ({ track: vi.fn() }))
+
+const server = setupServer()
+
+let editMode: ReturnType<typeof usePlaylistEditMode>
+const Probe = () => {
+  editMode = usePlaylistEditMode()
+  return null
+}
+
+const renderField = (collection: typeof testCollection & any) => {
+  server.use(mockCollectionById(collection))
+  return render(
+    <PlaylistEditModeProvider collectionId={1} isOwner>
+      <Probe />
+      <InlineAlbumPriceAndAudience collectionId={1} />
+    </PlaylistEditModeProvider>
+  )
+}
+
+describe('InlineAlbumPriceAndAudience', () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }))
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  it('shows the Price & Audience setting for a free album', async () => {
+    renderField({ ...testCollection, is_album: true })
+    await act(async () => editMode.enterEditMode())
+
+    await waitFor(() => {
+      expect(screen.getByText('Price & Audience')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Free for Everyone')).toBeInTheDocument()
+  })
+
+  it('shows the current price for a premium album', async () => {
+    renderField({
+      ...testCollection,
+      is_album: true,
+      is_stream_gated: true,
+      stream_conditions: { usdc_purchase: { price: 500, splits: [] } }
+    })
+    await act(async () => editMode.enterEditMode())
+
+    await waitFor(() => {
+      expect(screen.getByText('Price & Audience')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Premium')).toBeInTheDocument()
+    expect(screen.getByTestId('price-display')).toHaveTextContent('$5.00')
+  })
+})

--- a/packages/web/src/components/collection/desktop/edit-mode/InlineAlbumPriceAndAudience.tsx
+++ b/packages/web/src/components/collection/desktop/edit-mode/InlineAlbumPriceAndAudience.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useRef } from 'react'
+
+import { useCollection } from '@audius/common/api'
+import { AccessConditions, ID } from '@audius/common/models'
+import { Nullable } from '@audius/common/utils'
+import { Formik, useFormikContext } from 'formik'
+
+import { PriceAndAudienceField } from 'components/edit/fields/price-and-audience'
+
+import {
+  PlaylistAccessDraft,
+  usePlaylistEditMode
+} from './PlaylistEditModeContext'
+
+/**
+ * The subset of collection form values that PriceAndAudienceField reads and
+ * writes. Mirrors the shape the dedicated edit page's Formik form provides so
+ * the field behaves identically here (confirmation modal included).
+ */
+type AccessFormValues = PlaylistAccessDraft & {
+  is_private: boolean
+  is_scheduled_release: boolean
+  // PriceAndAudienceField also writes the download-gate fields; albums don't
+  // persist them, so they live only in this local form.
+  is_download_gated: Nullable<boolean>
+  download_conditions: Nullable<AccessConditions>
+  is_downloadable: boolean
+  preview_start_seconds?: Nullable<number>
+  field_visibility?: unknown
+  last_gate_keeper: Record<string, never>
+  is_owned_by_user: boolean
+}
+
+const noop = () => {}
+
+/**
+ * Pushes the access fields from the local Formik form into the inline
+ * edit-mode draft whenever PriceAndAudienceField commits a change, so that
+ * Apply persists them alongside the other staged edits.
+ */
+const AccessDraftSync = () => {
+  const { values } = useFormikContext<AccessFormValues>()
+  const { setField } = usePlaylistEditMode()
+  const isFirstRender = useRef(true)
+  const { is_stream_gated, stream_conditions } = values
+
+  useEffect(() => {
+    // The initial values are the collection's current values; only sync once
+    // the user has actually changed something.
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    setField('is_stream_gated', is_stream_gated ?? false)
+    setField('stream_conditions', stream_conditions ?? null)
+  }, [setField, is_stream_gated, stream_conditions])
+
+  return null
+}
+
+type InlineAlbumPriceAndAudienceProps = {
+  collectionId: ID
+}
+
+/**
+ * Renders the album "Price & Audience" settings (free vs. pay-to-unlock)
+ * inside the collection page's inline edit mode. The dedicated /edit page
+ * has always offered this; the inline editor replaced the pencil link to that
+ * page, so albums need it here too.
+ */
+export const InlineAlbumPriceAndAudience = (
+  props: InlineAlbumPriceAndAudienceProps
+) => {
+  const { collectionId } = props
+  const { data: collection } = useCollection(collectionId)
+
+  const initialValues = useMemo<AccessFormValues | null>(() => {
+    if (!collection) return null
+    return {
+      is_private: collection.is_private ?? false,
+      is_scheduled_release: collection.is_scheduled_release ?? false,
+      is_stream_gated: collection.is_stream_gated ?? false,
+      stream_conditions: collection.stream_conditions ?? null,
+      is_download_gated: false,
+      download_conditions: null,
+      is_downloadable: false,
+      preview_start_seconds: undefined,
+      field_visibility: undefined,
+      last_gate_keeper: {},
+      is_owned_by_user: false
+    }
+    // Only seed the form once per edit session; later cache updates (e.g. the
+    // optimistic update on Apply) must not reset in-progress edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [collection?.playlist_id])
+
+  if (!initialValues) return null
+
+  return (
+    <Formik<AccessFormValues> initialValues={initialValues} onSubmit={noop}>
+      <>
+        <AccessDraftSync />
+        <PriceAndAudienceField isAlbum isUpload={false} />
+      </>
+    </Formik>
+  )
+}

--- a/packages/web/src/components/collection/desktop/edit-mode/PlaylistEditModeContext.test.tsx
+++ b/packages/web/src/components/collection/desktop/edit-mode/PlaylistEditModeContext.test.tsx
@@ -1,0 +1,121 @@
+import { act } from '@testing-library/react'
+import { setupServer } from 'msw/node'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  vi
+} from 'vitest'
+
+import { testCollection } from 'test/mocks/fixtures/collections'
+import { mockCollectionById } from 'test/msw/mswMocks'
+import { it, render, waitFor } from 'test/test-utils'
+
+import {
+  PlaylistEditModeProvider,
+  usePlaylistEditMode
+} from './PlaylistEditModeContext'
+
+const dispatchSpy = vi.fn()
+
+vi.mock('react-redux', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-redux')>()
+  return { ...actual, useDispatch: () => dispatchSpy }
+})
+
+vi.mock('services/analytics', () => ({ track: vi.fn() }))
+
+const server = setupServer()
+
+const premiumConditions = { usdc_purchase: { price: 500, splits: [] } }
+
+const testAlbum = {
+  ...testCollection,
+  is_album: true,
+  is_stream_gated: false,
+  stream_conditions: null
+}
+
+type EditMode = ReturnType<typeof usePlaylistEditMode>
+
+let editMode: EditMode
+const Probe = () => {
+  editMode = usePlaylistEditMode()
+  return null
+}
+
+const renderProvider = () => {
+  server.use(mockCollectionById(testAlbum))
+  return render(
+    <PlaylistEditModeProvider collectionId={1} isOwner>
+      <Probe />
+    </PlaylistEditModeProvider>
+  )
+}
+
+describe('PlaylistEditModeContext access staging', () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }))
+  beforeEach(() => dispatchSpy.mockClear())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  it('marks the draft dirty when stream conditions change', async () => {
+    renderProvider()
+    await act(async () => editMode.enterEditMode())
+    expect(editMode.hasChanges).toBe(false)
+
+    await act(async () => {
+      editMode.setField('is_stream_gated', true)
+      editMode.setField('stream_conditions', premiumConditions)
+    })
+
+    await waitFor(() => expect(editMode.hasChanges).toBe(true))
+  })
+
+  it('is clean again when access is set back to its saved value', async () => {
+    renderProvider()
+    await act(async () => editMode.enterEditMode())
+
+    await act(async () => {
+      editMode.setField('is_stream_gated', true)
+      editMode.setField('stream_conditions', premiumConditions)
+    })
+    await waitFor(() => expect(editMode.hasChanges).toBe(true))
+
+    await act(async () => {
+      editMode.setField('is_stream_gated', false)
+      editMode.setField('stream_conditions', null)
+    })
+
+    expect(editMode.hasChanges).toBe(false)
+  })
+
+  it('passes staged stream conditions to editPlaylist on apply', async () => {
+    renderProvider()
+    await act(async () => editMode.enterEditMode())
+    await act(async () => {
+      editMode.setField('is_stream_gated', true)
+      editMode.setField('stream_conditions', premiumConditions)
+    })
+    await waitFor(() => expect(editMode.hasChanges).toBe(true))
+
+    await act(async () => editMode.apply())
+
+    await waitFor(() => {
+      const editAction = dispatchSpy.mock.calls
+        .map(([action]) => action)
+        .find((action) => action?.type === 'EDIT_PLAYLIST')
+      expect(editAction).toBeDefined()
+      expect(editAction.playlistId).toBe(1)
+      expect(editAction.formFields.is_stream_gated).toBe(true)
+      expect(editAction.formFields.stream_conditions).toEqual(premiumConditions)
+      // Untouched fields still come from the collection itself
+      expect(editAction.formFields.playlist_name).toBe(
+        testCollection.playlist_name
+      )
+    })
+  })
+})

--- a/packages/web/src/components/collection/desktop/edit-mode/PlaylistEditModeContext.tsx
+++ b/packages/web/src/components/collection/desktop/edit-mode/PlaylistEditModeContext.tsx
@@ -10,14 +10,18 @@ import {
 } from 'react'
 
 import { useCollection, useCollectionTracks } from '@audius/common/api'
-import { ID } from '@audius/common/models'
+import { AccessConditions, ID, Name } from '@audius/common/models'
 import {
   cacheCollectionsActions,
   EditCollectionValues,
   toastActions
 } from '@audius/common/store'
+import { Nullable } from '@audius/common/utils'
+import { isEqual } from 'lodash'
 import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router'
+
+import { track } from 'services/analytics'
 
 import { isDraftCollection, removeDraftCollection } from './draftCollections'
 import { useCreateDraftPlaylist } from './useCreateDraftPlaylist'
@@ -31,12 +35,48 @@ type ArtworkDraft = {
   source?: string
 }
 
+/**
+ * Access ("Price & Audience") fields that can be staged for albums. These are
+ * the fields the album update actually carries to the SDK; Apply hands them to
+ * the editPlaylist saga, which fills in the USDC splits for a newly premium
+ * album.
+ */
+export type PlaylistAccessDraft = {
+  is_stream_gated?: Nullable<boolean>
+  stream_conditions?: Nullable<AccessConditions>
+}
+
+export const ACCESS_DRAFT_FIELDS = [
+  'is_stream_gated',
+  'stream_conditions'
+] as const
+
 export type PlaylistMetadataDraft = {
   playlist_name?: string
   description?: string | null
   is_private?: boolean
   artwork?: ArtworkDraft | null
-}
+} & PlaylistAccessDraft
+
+/** Picks only the access fields that were actually staged. */
+const stagedAccessFields = (
+  draft: PlaylistMetadataDraft
+): PlaylistAccessDraft => ({
+  ...(draft.is_stream_gated !== undefined
+    ? { is_stream_gated: draft.is_stream_gated }
+    : {}),
+  ...(draft.stream_conditions !== undefined
+    ? { stream_conditions: draft.stream_conditions }
+    : {})
+})
+
+const accessFieldChanged = (
+  draft: PlaylistMetadataDraft,
+  collection: Record<string, unknown>,
+  field: (typeof ACCESS_DRAFT_FIELDS)[number]
+) =>
+  draft[field] !== undefined &&
+  !isEqual(draft[field] ?? null, collection[field] ?? null)
 
 type Status = 'idle' | 'saving' | 'conflict'
 
@@ -253,6 +293,11 @@ export const PlaylistEditModeProvider = ({
       }
     }
     if (draft.artwork !== undefined && draft.artwork !== null) return true
+    for (const f of ACCESS_DRAFT_FIELDS) {
+      if (accessFieldChanged(draft, collection as Record<string, unknown>, f)) {
+        return true
+      }
+    }
     return false
   }, [collection, draft, removedTrackIds, isCreate, draftTrackCount])
 
@@ -351,13 +396,32 @@ export const PlaylistEditModeProvider = ({
         draft.is_private !== undefined
           ? draft.is_private
           : collection.is_private,
-      artwork: draft.artwork ?? { url: '' }
+      artwork: draft.artwork ?? { url: '' },
+      ...stagedAccessFields(draft)
     } as EditCollectionValues
+
+    const accessChanged = accessFieldChanged(
+      draft,
+      collection as Record<string, unknown>,
+      'stream_conditions'
+    )
+    if (accessChanged) {
+      // Mirror the dedicated edit page: access changes get their own event.
+      track({
+        eventName: Name.COLLECTION_EDIT_ACCESS_CHANGED,
+        properties: {
+          id: collection.playlist_id,
+          from: collection.stream_conditions,
+          to: draft.stream_conditions
+        }
+      })
+    }
 
     const savedDetails =
       draft.playlist_name !== undefined ||
       draft.description !== undefined ||
-      draft.is_private !== undefined
+      draft.is_private !== undefined ||
+      accessChanged
     const savedArtwork = draft.artwork != null
     const savedTracks = removedTrackIds.size > 0
 


### PR DESCRIPTION
## Summary
- Since the playlist-editing overhaul (#14383, #14393, #14421) the pencil on an album page toggles the inline edit mode instead of linking to `/edit`, and nothing else links to that page anymore. That page is the only place an owner could switch a released album between free and pay-to-unlock, so Chillhop reported the feature as removed (see Slack, Sept 8).
- Stages `is_stream_gated` / `stream_conditions` in the inline edit-mode draft and sends them through the same `editPlaylist` saga the edit page uses, which populates the USDC splits for a newly premium album.
- Hosts the existing `PriceAndAudienceField` in a small local Formik form on the album header while editing (in place of the gated-content banner) and syncs its result into the draft. The existing "Confirm Update" access-confirmation modal still gates the change; it is a global NiceModal.
- Fires `COLLECTION_EDIT_ACCESS_CHANGED` on Apply, mirroring the edit page.
- Playlists are unaffected; only albums carry access settings.

## Test plan
- [x] `vitest` — new tests cover draft dirty-tracking, apply payload, and rendering of the field for free and premium albums
- [x] `tsc` and `eslint` clean for `packages/web`
- [ ] On a free album you own: pencil → "Price & Audience" tile shows "Free for Everyone" → choose Premium, set price → confirm the "Confirm Update" modal → Apply → album page shows PAY TO UNLOCK with the price
- [ ] On a premium album you own: tile shows Premium + price → switch to Free → Apply → banner disappears
- [ ] Playlist edit mode is unchanged (no Price & Audience tile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
