### PR TITLE
Fix artist profile links in embedded players

### DIFF
--- a/packages/embed/src/components/titles/Titles.jsx
+++ b/packages/embed/src/components/titles/Titles.jsx
@@ -9,7 +9,7 @@ import {
   IconTokenPlatinum
 } from '@audius/harmony'
 
-import { getCopyableLink } from '../../util/shareUtil'
+import { getAudiusURL, getCopyableLink } from '../../util/shareUtil'
 
 import styles from './Titles.module.css'
 
@@ -57,7 +57,7 @@ const Titles = ({
   }
 
   const onClickArtist = () => {
-    window.open(getCopyableLink(handle), '_blank')
+    window.open(getCopyableLink(`${getAudiusURL()}/${handle}`), '_blank')
   }
 
   return (


### PR DESCRIPTION
Clicking an artist name in an embedded track or playlist opened the bare handle as a relative URL, sending listeners to an invalid embed route. Build an absolute Audius profile URL with the existing environment-aware helper and retain `#embed` attribution.

Validation: all 3 embed Jest tests passed; `npm run verify` passed (ESLint and environment lint); exercised the actual artist and title click handlers to verify profile destinations and unchanged title links.

Report: https://audius-internal.slack.com/archives/CA80RCL77/p1788976550265479
