### PR TITLE
Link environment linter before embed deployment checks

### DIFF
--- a/.github/workflows/embed.yml
+++ b/.github/workflows/embed.yml
@@ -34,6 +34,8 @@ jobs:
           npm ci --prefer-offline || npm install --prefer-offline
       - name: Build workspace dependencies
         run: npx turbo run build --filter='embed^...'
+      - name: Link environment linter executable
+        run: npm run rebuild -w @audius/dotenv-linter
       - name: Verify embed
         working-directory: packages/embed
         run: |


### PR DESCRIPTION
The first embed deployment run passed dependency builds, Jest tests, and ESLint, then stopped because npm had not linked the dotenv-linter executable installed by its workspace install script. Run that workspace's existing rebuild command before verification to create the bin link.

Failure: https://github.com/AudiusProject/apps/actions/runs/34388974321
Validation: verified the existing dotenv-linter rebuild script and git diff --check.
