### PR TITLE
fix(profile): allow verified users to edit social handles

### DIFF
--- a/packages/mobile/src/screens/edit-profile-screen/EditProfileScreen.tsx
+++ b/packages/mobile/src/screens/edit-profile-screen/EditProfileScreen.tsx
@@ -42,23 +42,10 @@ const useStyles = makeStyles(({ spacing }) => ({
   }
 }))
 
-type EditProfileFormProps = FormikProps<ProfileValues> & {
-  isXVerified: boolean
-  isInstagramVerified: boolean
-  isTikTokVerified: boolean
-}
+type EditProfileFormProps = FormikProps<ProfileValues>
 
 const EditProfileForm = (props: EditProfileFormProps) => {
-  const {
-    handleSubmit,
-    handleReset,
-    isXVerified,
-    isInstagramVerified,
-    isTikTokVerified,
-    errors,
-    values,
-    setFieldValue
-  } = props
+  const { handleSubmit, handleReset, errors, values, setFieldValue } = props
   const styles = useStyles()
 
   const handleFanClubBadgeChange = useCallback(
@@ -112,7 +99,6 @@ const EditProfileForm = (props: EditProfileFormProps) => {
                 placeholder='username'
                 startAdornmentText='@'
                 startIcon={IconX}
-                editable={!isXVerified}
                 noGutter
               />
               <TextField
@@ -121,7 +107,6 @@ const EditProfileForm = (props: EditProfileFormProps) => {
                 placeholder='username'
                 startAdornmentText='@'
                 startIcon={IconInstagram}
-                editable={!isInstagramVerified}
                 noGutter
               />
               <TextField
@@ -130,7 +115,6 @@ const EditProfileForm = (props: EditProfileFormProps) => {
                 placeholder='username'
                 startAdornmentText='@'
                 startIcon={IconTikTok}
-                editable={!isTikTokVerified}
                 noGutter
               />
             </Flex>
@@ -225,9 +209,6 @@ export const EditProfileScreen = () => {
   if (!profile) return null
 
   const {
-    verified_with_twitter: verifiedWithX = false,
-    verified_with_instagram: verifiedWithInstagram = false,
-    verified_with_tiktok: verifiedWithTiktok = false,
     name = '',
     bio = null,
     location = null,
@@ -265,14 +246,7 @@ export const EditProfileScreen = () => {
       enableReinitialize
     >
       {(formikProps) => {
-        return (
-          <EditProfileForm
-            {...formikProps}
-            isXVerified={verifiedWithX}
-            isInstagramVerified={verifiedWithInstagram}
-            isTikTokVerified={verifiedWithTiktok}
-          />
-        )
+        return <EditProfileForm {...formikProps} />
       }}
     </Formik>
   )

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
@@ -68,9 +68,6 @@ type ProfileLeftNavProps = {
       ticker: string
     } | null
   ) => void
-  twitterVerified: boolean
-  instagramVerified: boolean
-  tikTokVerified: boolean
   isOwner: boolean
 }
 
@@ -98,9 +95,6 @@ export const ProfileLeftNav = (props: ProfileLeftNavProps) => {
     onUpdateBio,
     fanClubBadge,
     onUpdateFanClubBadge,
-    twitterVerified,
-    instagramVerified,
-    tikTokVerified,
     isOwner
   } = props
 
@@ -168,19 +162,16 @@ export const ProfileLeftNav = (props: ProfileLeftNavProps) => {
             </Text>
             <SocialLinkInput
               defaultValue={twitterHandle}
-              isDisabled={!!twitterVerified}
               type={Type.X}
               onChange={onUpdateTwitterHandle}
             />
             <SocialLinkInput
               defaultValue={instagramHandle}
-              isDisabled={!!instagramVerified}
               type={Type.INSTAGRAM}
               onChange={onUpdateInstagramHandle}
             />
             <SocialLinkInput
               defaultValue={tikTokHandle}
-              isDisabled={!!tikTokVerified}
               type={Type.TIKTOK}
               onChange={onUpdateTikTokHandle}
             />

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -109,9 +109,6 @@ const ProfilePage = ({ containerRef }: ProfilePageProps) => {
     twitterHandle,
     instagramHandle,
     tikTokHandle,
-    twitterVerified,
-    instagramVerified,
-    tikTokVerified,
     website,
     fanClubBadge,
     hasProfilePicture,
@@ -629,9 +626,6 @@ const ProfilePage = ({ containerRef }: ProfilePageProps) => {
                   twitterHandle={twitterHandle}
                   instagramHandle={instagramHandle}
                   tikTokHandle={tikTokHandle}
-                  twitterVerified={twitterVerified}
-                  instagramVerified={instagramVerified}
-                  tikTokVerified={tikTokVerified}
                   website={website}
                   fanClubBadge={fanClubBadge}
                   created={created}

--- a/packages/web/src/pages/profile-page/components/mobile/EditProfile.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/EditProfile.tsx
@@ -17,9 +17,6 @@ type EditProfileProps = {
   xHandle: string
   instagramHandle: string
   tikTokHandle: string
-  twitterVerified: boolean
-  instagramVerified: boolean
-  tikTokVerified: boolean
   website: string
 
   onUpdateName: (name: string) => void
@@ -38,9 +35,6 @@ const EditProfile = ({
   xHandle,
   instagramHandle,
   tikTokHandle,
-  twitterVerified,
-  instagramVerified,
-  tikTokVerified,
   website,
   onUpdateName,
   onUpdateBio,
@@ -82,7 +76,6 @@ const EditProfile = ({
             onChange={onUpdateXHandle}
             maxLength={200}
             inputPrefix='@'
-            isDisabled={!!twitterVerified}
           />
           <EditableRow
             label={<IconInstagram className={styles.icon} />}
@@ -91,7 +84,6 @@ const EditProfile = ({
             onChange={onUpdateInstagramHandle}
             maxLength={200}
             inputPrefix='@'
-            isDisabled={!!instagramVerified}
           />
           <EditableRow
             label={<IconTikTok className={styles.icon} />}
@@ -100,7 +92,6 @@ const EditProfile = ({
             onChange={onUpdateTikTokHandle}
             maxLength={200}
             inputPrefix='@'
-            isDisabled={!!tikTokVerified}
           />
           <EditableRow
             label={<IconLink className={styles.icon} />}

--- a/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
@@ -87,9 +87,6 @@ const ProfilePage = ({ containerRef }: ProfilePageProps) => {
     twitterHandle,
     instagramHandle,
     tikTokHandle,
-    twitterVerified,
-    instagramVerified,
-    tikTokVerified,
     website,
     hasProfilePicture,
     following,
@@ -417,9 +414,6 @@ const ProfilePage = ({ containerRef }: ProfilePageProps) => {
         xHandle={xHandle}
         instagramHandle={instagramHandle}
         tikTokHandle={tikTokHandle}
-        twitterVerified={twitterVerified}
-        instagramVerified={instagramVerified}
-        tikTokVerified={tikTokVerified}
         website={website}
         onUpdateName={updateName}
         onUpdateBio={updateBio}

--- a/packages/web/src/pages/profile-page/useProfilePage.ts
+++ b/packages/web/src/pages/profile-page/useProfilePage.ts
@@ -49,7 +49,6 @@ import {
 import { ProfileMode } from 'components/stat-banner/StatBanner'
 import { StatProps } from 'components/stats/Stats'
 import * as unfollowConfirmationActions from 'components/unfollow-confirmation-modal/store/actions'
-import { verifiedHandleWhitelist } from 'utils/handleWhitelist'
 import { resizeImage } from 'utils/imageProcessingUtil'
 import { push, replace } from 'utils/navigation'
 import { getPathname } from 'utils/route'
@@ -271,11 +270,7 @@ export const useProfilePage = () => {
   const stats = getStats(isArtist ?? false)
 
   const userId = profile ? profile.user_id : null
-  const handle = profile ? `@${profile.handle}` : ''
   const verified = profile ? profile.is_verified : false
-  const twitterVerified = !!profile?.verified_with_twitter
-  const instagramVerified = !!profile?.verified_with_instagram
-  const tikTokVerified = !!profile?.verified_with_tiktok
   const created = profile
     ? dayjs(profile.created_at).format('YYYY')
     : dayjs().format('YYYY')
@@ -289,23 +284,17 @@ export const useProfilePage = () => {
   const twitterHandle = profile
     ? updatedTwitterHandle !== null
       ? updatedTwitterHandle
-      : twitterVerified && !verifiedHandleWhitelist.has(handle)
-        ? profile.handle
-        : (profile.twitter_handle ?? '')
+      : (profile.twitter_handle ?? '')
     : ''
   const instagramHandle = profile
     ? updatedInstagramHandle !== null
       ? updatedInstagramHandle
-      : instagramVerified
-        ? profile.handle
-        : (profile.instagram_handle ?? '')
+      : (profile.instagram_handle ?? '')
     : ''
   const tikTokHandle = profile
     ? updatedTikTokHandle !== null
       ? updatedTikTokHandle
-      : tikTokVerified
-        ? profile.handle
-        : (profile.tiktok_handle ?? '')
+      : (profile.tiktok_handle ?? '')
     : ''
   const website =
     profile && updatedWebsite !== null
@@ -838,9 +827,6 @@ export const useProfilePage = () => {
     twitterHandle,
     instagramHandle,
     tikTokHandle,
-    twitterVerified,
-    instagramVerified,
-    tikTokVerified,
     website,
     fanClubBadge,
     hasProfilePicture: !!hasProfilePicture,

--- a/packages/web/src/pages/profile-page/useProfilePage.ts
+++ b/packages/web/src/pages/profile-page/useProfilePage.ts
@@ -270,6 +270,7 @@ export const useProfilePage = () => {
   const stats = getStats(isArtist ?? false)
 
   const userId = profile ? profile.user_id : null
+  const handle = profile ? `@${profile.handle}` : ''
   const verified = profile ? profile.is_verified : false
   const created = profile
     ? dayjs(profile.created_at).format('YYYY')

--- a/packages/web/src/utils/handleWhitelist.ts
+++ b/packages/web/src/utils/handleWhitelist.ts
@@ -1,9 +1,0 @@
-// These Audius handles represent a list of accounts that are in a
-// messed up state (they were able to change their handle) but oauth
-// with twitter, which ends up forcing them to show the wrong twitter
-// link on their profile.
-export const verifiedHandleWhitelist = new Set([
-  'miquela',
-  'JodyBreeze',
-  'masego'
-])


### PR DESCRIPTION
Verified users could not edit their X, Instagram, or TikTok handles on desktop web, mobile web, or native. Web profiles also substituted the Audius username for verified social handles, so a renamed account could display and link to the wrong handle even after its stored value was corrected.

Enable editing for all three social fields and render their stored values on web. Remove the obsolete Twitter handle whitelist and the verification props used only to disable these inputs. Existing account and social verification flags are unchanged.

Validation: ESLint passes for all changed web files, and the diff passes whitespace checks. Full web and native type checks could not pass in this worktree because of dependency/configuration errors, including missing wagmi modules and the React Native TypeScript configuration. Native lint is also blocked by that missing configuration. An authenticated save flow and native runtime have not been exercised; clearing a social handle remains subject to the existing backend behavior and is not fixed here.
